### PR TITLE
Feature/KOJO-28 | Namespace Sever and Redis locks 

### DIFF
--- a/src/Environment/Parameters.yml
+++ b/src/Environment/Parameters.yml
@@ -6,3 +6,4 @@ parameters:
   neighborhoods.kojo.environment.parameters.database_adapter: ''
   neighborhoods.kojo.environment.parameters.database_host: ''
   neighborhoods.kojo.environment.parameters.database_name: ''
+  neighborhoods.kojo.environment.parameters.lock_prefix: ''

--- a/src/Message/Broker/Redis.yml
+++ b/src/Message/Broker/Redis.yml
@@ -4,8 +4,8 @@ services:
     shared: false
     calls:
       - [setLogger, ['@process.pool.logger']]
-      - [setSubscriptionChannelName, ['job_listener_subscribe']]
-      - [setPublishChannelName, ['job_listener_publish']]
+      - [setSubscriptionChannelName, ['%neighborhoods.kojo.environment.parameters.lock_prefix%job_listener_subscribe']]
+      - [setPublishChannelName, ['%neighborhoods.kojo.environment.parameters.lock_prefix%job_listener_publish']]
       - [setRedisRepository, ['@redis.repository']]
   message.broker.redis:
     alias: neighborhoods.kojo.message.broker.redis

--- a/src/Scheduler/Cache.php
+++ b/src/Scheduler/Cache.php
@@ -3,10 +3,10 @@ declare(strict_types=1);
 
 namespace Neighborhoods\Kojo\Scheduler;
 
-use Neighborhoods\Pylon\Data\Property\Defensive;
-use Neighborhoods\Kojo\Scheduler;
-use Neighborhoods\Pylon\Time;
 use Neighborhoods\Kojo\CacheItemPool;
+use Neighborhoods\Kojo\Scheduler;
+use Neighborhoods\Pylon\Data\Property\Defensive;
+use Neighborhoods\Pylon\Time;
 
 class Cache implements CacheInterface
 {
@@ -16,9 +16,9 @@ class Cache implements CacheInterface
     use CacheItemPool\Repository\AwareTrait;
     protected $_scheduleMinutesNotInCache = [];
     /** @var string */
-    protected $cacheScheduledAheadKeyPrefix;
+    protected $lock_prefix;
 
-    public function getMinutesNotInCache(): array
+    public function getMinutesNotInCache() : array
     {
         if (empty($this->_scheduleMinutesNotInCache)) {
             $nexReferenceMinuteDateTime = $this->_getSchedulerTime()->getNextReferenceMinuteDateTime();
@@ -35,12 +35,14 @@ class Cache implements CacheInterface
         return $this->_scheduleMinutesNotInCache;
     }
 
-    protected function _isMinuteScheduledInCache(\DateTime $referenceMinuteDateTime): bool
+    protected function _isMinuteScheduledInCache(\DateTime $referenceMinuteDateTime) : bool
     {
         $isMinuteScheduled = false;
         $referenceMinuteDateTimeString = $referenceMinuteDateTime->format(self::DATE_TIME_FORMAT_CACHE_MINUTE);
         $cacheItemPool = $this->_getCacheItemPoolRepository()->getById(self::CACHE_ITEM_POOL_ID);
-        $hasItem = $cacheItemPool->hasItem($this->getCacheScheduledAheadKeyPrefix() . $referenceMinuteDateTimeString);
+        $hasItem = $cacheItemPool->hasItem(
+            $this->getLockPrefix() . self::CACHE_SCHEDULED_AHEAD_KEY_PREFIX . $referenceMinuteDateTimeString
+        );
         if ($hasItem) {
             $isMinuteScheduled = true;
         }
@@ -48,7 +50,7 @@ class Cache implements CacheInterface
         return $isMinuteScheduled;
     }
 
-    protected function _getScheduledKeyLifetime(): \DateTime
+    protected function _getScheduledKeyLifetime() : \DateTime
     {
         if (!$this->_exists(self::PROP_SCHEDULED_KEY_LIFETIME)) {
             $now = $this->_getTime()->getNow();
@@ -60,11 +62,13 @@ class Cache implements CacheInterface
         return $this->_read(self::PROP_SCHEDULED_KEY_LIFETIME);
     }
 
-    public function cacheScheduledMinutes(\DateTime $scheduledMinute): CacheInterface
+    public function cacheScheduledMinutes(\DateTime $scheduledMinute) : CacheInterface
     {
         $cacheItemPool = $this->_getCacheItemPoolRepository()->getById(self::CACHE_ITEM_POOL_ID);
         $cachedMinuteDateTimeString = $scheduledMinute->format(self::DATE_TIME_FORMAT_CACHE_MINUTE);
-        $cacheItem = $cacheItemPool->getItem($this->getCacheScheduledAheadKeyPrefix() . $cachedMinuteDateTimeString);
+        $cacheItem = $cacheItemPool->getItem(
+            $this->getLockPrefix() . self::CACHE_SCHEDULED_AHEAD_KEY_PREFIX . $cachedMinuteDateTimeString
+        );
         $cacheItem->set(self::CACHE_SCHEDULED_AHEAD_VALUE);
         $cacheItem->expiresAt($this->_getScheduledKeyLifetime());
         $cacheItemPool->save($cacheItem);
@@ -72,22 +76,22 @@ class Cache implements CacheInterface
         return $this;
     }
 
-    public function getCacheScheduledAheadKeyPrefix() : string
+    public function getLockPrefix() : string
     {
-        if ($this->cacheScheduledAheadKeyPrefix === null) {
-            return self::CACHE_SCHEDULED_AHEAD_KEY_PREFIX;
+        if ($this->lock_prefix === null) {
+            return '';
         }
 
-        return $this->cacheScheduledAheadKeyPrefix;
+        return $this->lock_prefix;
     }
 
-    public function setCacheScheduledAheadKeyPrefix(string $cacheScheduledAheadKeyPrefix) : CacheInterface
+    public function setLockPrefix(string $lock_prefix) : CacheInterface
     {
-        if ($this->cacheScheduledAheadKeyPrefix !== null) {
+        if ($this->lock_prefix !== null) {
             throw new \LogicException('Cache cacheScheduledAheadKeyPrefix is already set.');
         }
 
-        $this->cacheScheduledAheadKeyPrefix = $cacheScheduledAheadKeyPrefix;
+        $this->lock_prefix = $lock_prefix;
 
         return $this;
     }

--- a/src/Scheduler/Cache.yml
+++ b/src/Scheduler/Cache.yml
@@ -6,6 +6,6 @@ services:
       - [setSchedulerTime, ['@scheduler.time']]
       - [setCacheItemPoolRepository, ['@cache_item_pool.repository']]
       - [setTime, ['@neighborhoods.pylon.time']]
-      - [setCacheScheduledAheadKeyPrefix, ['%neighborhoods.kojo.environment.parameters.lock_prefix%']]
+      - [setLockPrefix, ['%neighborhoods.kojo.environment.parameters.lock_prefix%']]
   scheduler.cache:
     alias: neighborhoods.kojo.scheduler.cache

--- a/src/Scheduler/Cache.yml
+++ b/src/Scheduler/Cache.yml
@@ -6,5 +6,6 @@ services:
       - [setSchedulerTime, ['@scheduler.time']]
       - [setCacheItemPoolRepository, ['@cache_item_pool.repository']]
       - [setTime, ['@neighborhoods.pylon.time']]
+      - [setCacheScheduledAheadKeyPrefix, ['%neighborhoods.kojo.environment.parameters.lock_prefix%']]
   scheduler.cache:
     alias: neighborhoods.kojo.scheduler.cache

--- a/src/Scheduler/CacheInterface.php
+++ b/src/Scheduler/CacheInterface.php
@@ -19,4 +19,6 @@ interface CacheInterface
     public function getMinutesNotInCache(): array;
 
     public function cacheScheduledMinutes(\DateTime $scheduledMinute): CacheInterface;
+
+    public function setLockPrefix(string $cacheScheduledAheadKeyPrefix) : CacheInterface;
 }

--- a/src/Semaphore/Resource.yml
+++ b/src/Semaphore/Resource.yml
@@ -10,7 +10,7 @@ services:
     class: Neighborhoods\Kojo\Semaphore\Resource
     shared: false
     calls:
-      - [setResourceName, ['maintainer_delete.lock']]
+    - [setResourceName, ['%neighborhoods.kojo.environment.parameters.lock_prefix%maintainer_delete.lock']]
       - [setResourcePath, ['neighborhoods/kojo']]
       - [setIsBlocking, [false]]
   semaphore.resource-maintainer_delete:
@@ -19,7 +19,7 @@ services:
     class: Neighborhoods\Kojo\Semaphore\Resource
     shared: false
     calls:
-      - [setResourceName, ['update_pending_jobs.lock']]
+    - [setResourceName, ['%neighborhoods.kojo.environment.parameters.lock_prefix%update_pending_jobs.lock']]
       - [setResourcePath, ['neighborhoods/kojo']]
       - [setIsBlocking, [false]]
   semaphore.resource-update_pending_jobs:
@@ -28,7 +28,7 @@ services:
     class: Neighborhoods\Kojo\Semaphore\Resource
     shared: false
     calls:
-      - [setResourceName, ['reschedule_jobs.lock']]
+    - [setResourceName, ['%neighborhoods.kojo.environment.parameters.lock_prefix%reschedule_jobs.lock']]
       - [setResourcePath, ['neighborhoods/kojo']]
       - [setIsBlocking, [false]]
   semaphore.resource-reschedule_jobs:
@@ -36,7 +36,7 @@ services:
   neighborhoods.kojo.semaphore.resource-schedule:
     class: Neighborhoods\Kojo\Semaphore\Resource
     calls:
-      - [setResourceName, ['schedule.lock']]
+    - [setResourceName, ['%neighborhoods.kojo.environment.parameters.lock_prefix%schedule.lock']]
       - [setResourcePath, ['neighborhoods/kojo']]
       - [setIsBlocking, [false]]
     shared: false
@@ -46,7 +46,7 @@ services:
     class: Neighborhoods\Kojo\Semaphore\Resource
     shared: false
     calls:
-      - [setResourceName, ['server.lock']]
+    - [setResourceName, ['%neighborhoods.kojo.environment.parameters.lock_prefix%server.lock']]
       - [setResourcePath, ['neighborhoods/kojo']]
       - [setIsBlocking, [false]]
   semaphore.resource-server:

--- a/src/Semaphore/Resource.yml
+++ b/src/Semaphore/Resource.yml
@@ -10,7 +10,7 @@ services:
     class: Neighborhoods\Kojo\Semaphore\Resource
     shared: false
     calls:
-    - [setResourceName, ['%neighborhoods.kojo.environment.parameters.lock_prefix%maintainer_delete.lock']]
+      - [setResourceName, ['%neighborhoods.kojo.environment.parameters.lock_prefix%maintainer_delete.lock']]
       - [setResourcePath, ['neighborhoods/kojo']]
       - [setIsBlocking, [false]]
   semaphore.resource-maintainer_delete:
@@ -19,7 +19,7 @@ services:
     class: Neighborhoods\Kojo\Semaphore\Resource
     shared: false
     calls:
-    - [setResourceName, ['%neighborhoods.kojo.environment.parameters.lock_prefix%update_pending_jobs.lock']]
+      - [setResourceName, ['%neighborhoods.kojo.environment.parameters.lock_prefix%update_pending_jobs.lock']]
       - [setResourcePath, ['neighborhoods/kojo']]
       - [setIsBlocking, [false]]
   semaphore.resource-update_pending_jobs:
@@ -28,7 +28,7 @@ services:
     class: Neighborhoods\Kojo\Semaphore\Resource
     shared: false
     calls:
-    - [setResourceName, ['%neighborhoods.kojo.environment.parameters.lock_prefix%reschedule_jobs.lock']]
+      - [setResourceName, ['%neighborhoods.kojo.environment.parameters.lock_prefix%reschedule_jobs.lock']]
       - [setResourcePath, ['neighborhoods/kojo']]
       - [setIsBlocking, [false]]
   semaphore.resource-reschedule_jobs:
@@ -36,7 +36,7 @@ services:
   neighborhoods.kojo.semaphore.resource-schedule:
     class: Neighborhoods\Kojo\Semaphore\Resource
     calls:
-    - [setResourceName, ['%neighborhoods.kojo.environment.parameters.lock_prefix%schedule.lock']]
+      - [setResourceName, ['%neighborhoods.kojo.environment.parameters.lock_prefix%schedule.lock']]
       - [setResourcePath, ['neighborhoods/kojo']]
       - [setIsBlocking, [false]]
     shared: false
@@ -46,7 +46,7 @@ services:
     class: Neighborhoods\Kojo\Semaphore\Resource
     shared: false
     calls:
-    - [setResourceName, ['%neighborhoods.kojo.environment.parameters.lock_prefix%server.lock']]
+      - [setResourceName, ['%neighborhoods.kojo.environment.parameters.lock_prefix%server.lock']]
       - [setResourcePath, ['neighborhoods/kojo']]
       - [setIsBlocking, [false]]
   semaphore.resource-server:


### PR DESCRIPTION
## Changes
- Allow users to specify `neighborhoods.kojo.environment.parameters.lock_prefix` to allow multiple Kōjō servers on a single execution environment