### PR TITLE
Create a formatter for the \Throwable type and use when jobs Panic

### DIFF
--- a/src/Process/Job.php
+++ b/src/Process/Job.php
@@ -27,10 +27,7 @@ class Job extends Forked implements JobInterface
             $this->_getMaintainer()->deleteCompletedJobs();
             $this->_getForeman()->workWorker();
         } catch (\Throwable $throwable) {
-            $previousMessage = $this->_getLogger()->getLogFormatter()->getFormattedThrowableMessage(
-                $throwable->getPrevious()
-            );
-            $message = implode(' ', [$throwable->getMessage(), $previousMessage]);
+            $message = $this->_getLogger()->getLogFormatter()->getFormattedThrowableMessage($throwable);
             $this->_getLogger()->critical($message);
             $this->_setOrReplaceExitCode(255);
         }

--- a/src/Process/Job.php
+++ b/src/Process/Job.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 namespace Neighborhoods\Kojo\Process;
 
 use Neighborhoods\Kojo\Foreman;
-use Neighborhoods\Kojo\Scheduler;
 use Neighborhoods\Kojo\Maintainer;
-use Neighborhoods\Kojo\Selector;
 use Neighborhoods\Kojo\Process;
+use Neighborhoods\Kojo\Scheduler;
+use Neighborhoods\Kojo\Selector;
 
 class Job extends Forked implements JobInterface
 {
@@ -17,17 +17,21 @@ class Job extends Forked implements JobInterface
     use Selector\AwareTrait;
     use Process\Pool\Factory\AwareTrait;
 
-    protected function _run(): Forked
+    protected function _run() : Forked
     {
-        try{
+        try {
             $this->_getSelector()->setProcess($this);
             $this->_getMaintainer()->rescheduleCrashedJobs();
             $this->_getScheduler()->scheduleStaticJobs();
             $this->_getMaintainer()->updatePendingJobs();
             $this->_getMaintainer()->deleteCompletedJobs();
             $this->_getForeman()->workWorker();
-        }catch(\Throwable $throwable){
-            $this->_getLogger()->critical($throwable->getMessage());
+        } catch (\Throwable $throwable) {
+            $previousMessage = $this->_getLogger()->getLogFormatter()->getFormattedThrowableMessage(
+                $throwable->getPrevious()
+            );
+            $message = implode(' ', [$throwable->getMessage(), $previousMessage]);
+            $this->_getLogger()->critical($message);
             $this->_setOrReplaceExitCode(255);
         }
 

--- a/src/Process/Pool/Logger/Formatter.php
+++ b/src/Process/Pool/Logger/Formatter.php
@@ -30,8 +30,8 @@ class Formatter implements FormatterInterface
     public function getFormattedThrowableMessage(\Throwable $throwable): string
     {
         if ($throwable->getPrevious()) {
-            $previousType = get_class($throwable);
-            $previousMessage = $throwable->getMessage();
+            $previousType = get_class($throwable->getPrevious());
+            $previousMessage = $throwable->getPrevious()->getMessage();
             $previousMessage = "{$previousType}: {$previousMessage}";
             $message = implode(' ', [$throwable->getMessage(), $previousMessage]);
         } else {

--- a/src/Process/Pool/Logger/Formatter.php
+++ b/src/Process/Pool/Logger/Formatter.php
@@ -27,6 +27,13 @@ class Formatter implements FormatterInterface
         }
     }
 
+    public function getFormattedThrowableMessage(\Throwable $throwable): string
+    {
+        $throwableType = get_class($throwable);
+        $throwableMessage = $throwable->getMessage();
+        return "{$throwableType}: $throwableMessage}";
+    }
+
     protected function formatPipes(MessageInterface $message) : string
     {
         $processIdPaddingLength = $this->getProcessIdPadding();

--- a/src/Process/Pool/Logger/Formatter.php
+++ b/src/Process/Pool/Logger/Formatter.php
@@ -29,9 +29,16 @@ class Formatter implements FormatterInterface
 
     public function getFormattedThrowableMessage(\Throwable $throwable): string
     {
-        $throwableType = get_class($throwable);
-        $throwableMessage = $throwable->getMessage();
-        return "{$throwableType}: {$throwableMessage}";
+        if ($throwable->getPrevious()) {
+            $previousType = get_class($throwable);
+            $previousMessage = $throwable->getMessage();
+            $previousMessage = "{$previousType}: {$previousMessage}";
+            $message = implode(' ', [$throwable->getMessage(), $previousMessage]);
+        } else {
+            $message = $throwable->getMessage();
+        }
+
+        return $message;
     }
 
     protected function formatPipes(MessageInterface $message) : string

--- a/src/Process/Pool/Logger/Formatter.php
+++ b/src/Process/Pool/Logger/Formatter.php
@@ -31,7 +31,7 @@ class Formatter implements FormatterInterface
     {
         $throwableType = get_class($throwable);
         $throwableMessage = $throwable->getMessage();
-        return "{$throwableType}: $throwableMessage}";
+        return "{$throwableType}: {$throwableMessage}";
     }
 
     protected function formatPipes(MessageInterface $message) : string

--- a/src/Process/Pool/Logger/FormatterInterface.php
+++ b/src/Process/Pool/Logger/FormatterInterface.php
@@ -14,4 +14,6 @@ interface FormatterInterface
     public function setProcessIdPadding(int $processIdPadding) : FormatterInterface;
 
     public function setLogFormat(string $logFormat);
+
+    public function getFormattedThrowableMessage(\Throwable $throwable) : string;
 }


### PR DESCRIPTION
Previously Kōjō would create a log message panicking a job when an un-caught exception bubbled all the way up to the `\Neighborhoods\Kojo\Process\Job` level. This error message didn't provide any actionable info as to what caused the job to panic in the first place.

```json
{
  "time": "Wed, 10 Oct 18 16:14:27.887391 UTC",
  "level": "critical",
  "process_id": "290",
  "process_path": "/server[282]/root[286]/job[290]",
  "message": "Panicking job with ID[14]."
}
```

This pull request will take the "previous exception" attached to the \RunTimeException and run it through a formatter. This will help to give more context to what caused the job to panic.

```json
{
  "time": "Wed, 10 Oct 18 16:14:27.887391 UTC",
  "level": "critical",
  "process_id": "290",
  "process_path": "/server[282]/root[286]/job[290]",
  "message": "Panicking job with ID[14]. TypeError: Argument 1 passed to Neighborhoods\\KojoFitnessFunction42\\V1\\Worker\\Delegate::onlyTakesIntegers() must be of the type integer, string given, called in /var/www/html/kojo_fitness.neighborhoods.com/Function42/src/V1/Worker/Delegate.php on line 17}"
}
```