### PR TITLE
KOJO-49 | Expose Job ID in userspace

### DIFF
--- a/src/Api/V1/Worker/Service.php
+++ b/src/Api/V1/Worker/Service.php
@@ -128,4 +128,9 @@ class Service implements ServiceInterface
     {
         return $this->getApiV1JobSchedulerFactory()->create();
     }
+
+    public function getJobId(): int
+    {
+        return $this->_getJob()->getId();
+    }
 }

--- a/src/Api/V1/Worker/ServiceInterface.php
+++ b/src/Api/V1/Worker/ServiceInterface.php
@@ -33,6 +33,8 @@ interface ServiceInterface
 
     public function getTimesCrashed(): int;
 
+    public function getJobId(): int;
+
     /** @injected:configuration */
     public function setServiceUpdateRetryFactory(Retry\FactoryInterface $updateRetryFactory);
 


### PR DESCRIPTION
Sometimes workers need to be aware of their job ID (e.g. for patterns where a job's input data is stored externally, keyed by job ID)

Since this is purely an orthogonal addition to the userspace API, I'm not sure if a fitness function is necessary (or what it would demonstrate), but let me know if I should create one