### PR TITLE
KOJO-57 | Store DateTime from Worker retryRequest()

### DIFF
--- a/src/Api/V1/Worker/Service.php
+++ b/src/Api/V1/Worker/Service.php
@@ -33,6 +33,7 @@ class Service implements ServiceInterface
     public function requestRetry(\DateTime $retryDateTime): ServiceInterface
     {
         $this->_createOrUpdate(self::PROP_REQUEST, self::REQUEST_RETRY);
+        $this->_updateOrInsertDateTime($retryDateTime);
 
         return $this;
     }


### PR DESCRIPTION
Ran across this issue trying to use `requestRetry()` in userspace, the datetime provided by the worker is never stored.

[Fitness Function](https://github.com/neighborhoods/KojoFitness/pull/12)