### PR TITLE
KOJO-65 | Expose NewRelic class in userspace

### DIFF
--- a/src/Api/V1/Worker/Service.php
+++ b/src/Api/V1/Worker/Service.php
@@ -5,6 +5,7 @@ namespace Neighborhoods\Kojo\Api\V1\Worker;
 
 use Neighborhoods\Kojo\Api\V1\Job\SchedulerInterface;
 use Neighborhoods\Kojo\Api\V1\LoggerInterface;
+use Neighborhoods\Kojo\Apm;
 use Neighborhoods\Kojo\Data\Job;
 use Neighborhoods\Kojo\Service\Update;
 use Neighborhoods\Kojo\Api;
@@ -22,13 +23,14 @@ class Service implements ServiceInterface
     use Update\Complete\Failed\Factory\AwareTrait;
     use Create\Factory\AwareTrait;
     use Defensive\AwareTrait;
-    protected const     PROP_REQUEST = 'request';
-    protected const     PROP_RETRY_DATE_TIME = 'retry_date_time';
-    protected const     REQUEST_RETRY = 'retry';
-    protected const     REQUEST_HOLD = 'hold';
-    protected const     REQUEST_COMPLETE_SUCCESS = 'complete_success';
-    protected const     REQUEST_COMPLETE_FAILED = 'complete_failed';
-    protected const     PROP_REQUEST_APPLIED = 'request_applied';
+    use Apm\NewRelic\AwareTrait;
+    protected const PROP_REQUEST = 'request';
+    protected const PROP_RETRY_DATE_TIME = 'retry_date_time';
+    protected const REQUEST_RETRY = 'retry';
+    protected const REQUEST_HOLD = 'hold';
+    protected const REQUEST_COMPLETE_SUCCESS = 'complete_success';
+    protected const REQUEST_COMPLETE_FAILED = 'complete_failed';
+    protected const PROP_REQUEST_APPLIED = 'request_applied';
 
     public function requestRetry(\DateTime $retryDateTime): ServiceInterface
     {
@@ -138,5 +140,10 @@ class Service implements ServiceInterface
     public function getTimesRetried() : int
     {
         return $this->_getJob()->getTimesRetried();
+    }
+
+    public function getNewRelic() : Apm\NewRelicInterface
+    {
+        return $this->_getApmNewRelic();
     }
 }

--- a/src/Api/V1/Worker/Service.yml
+++ b/src/Api/V1/Worker/Service.yml
@@ -9,5 +9,6 @@ services:
       - [setServiceUpdateRetryFactory, ['@service.update.retry.factory']]
       - [setApiV1JobSchedulerFactory, ['@api.v1.job.scheduler.factory']]
       - [setApiV1Logger, ['@api.v1.logger']]
+      - [setApmNewRelic, ['@apm.new_relic']]
   api.v1.worker.service:
     alias: neighborhoods.kojo.api.v1.worker.service

--- a/src/Api/V1/Worker/ServiceInterface.php
+++ b/src/Api/V1/Worker/ServiceInterface.php
@@ -10,6 +10,7 @@ use Neighborhoods\Kojo\Service\Update\Hold;
 use Neighborhoods\Kojo\Service\Update\Retry;
 use Neighborhoods\Kojo\Service\Update\Complete\Success;
 use Neighborhoods\Kojo\Service\Update\Complete\Failed;
+use Neighborhoods\Kojo\Apm;
 
 interface ServiceInterface
 {
@@ -37,6 +38,8 @@ interface ServiceInterface
 
     public function getTimesRetried(): int;
 
+    public function getNewRelic(): Apm\NewRelicInterface;
+
     /** @injected:configuration */
     public function setServiceUpdateRetryFactory(Retry\FactoryInterface $updateRetryFactory);
 
@@ -48,6 +51,9 @@ interface ServiceInterface
 
     /** @injected:configuration */
     public function setServiceUpdateHoldFactory(Hold\FactoryInterface $updateHoldFactory);
+
+    /** @injected:configuration */
+    public function setApmNewRelic(Apm\NewRelicInterface $newRelic);
 
     /** @injected:runtime */
     public function setJob(JobInterface $job);

--- a/src/Foreman.php
+++ b/src/Foreman.php
@@ -28,7 +28,6 @@ class Foreman implements ForemanInterface
     use Update\Complete\Success\Factory\AwareTrait;
     use Defensive\AwareTrait;
     use Logger\AwareTrait;
-    use Apm\NewRelic\AwareTrait;
 
     public function workWorker(): ForemanInterface
     {
@@ -74,13 +73,8 @@ class Foreman implements ForemanInterface
     protected function _runWorker(): ForemanInterface
     {
         try {
-            $className = $this->_getLocator()->getClassName();
-            $methodName = $this->_getLocator()->getMethodName();
-            $this->_getApmNewRelic()->startTransaction();
-            $this->_getApmNewRelic()->nameTransaction($className . '::' . $methodName);
             $this->_injectWorkerService();
             call_user_func($this->_getLocator()->getCallable());
-            $this->_getApmNewRelic()->endTransaction();
         } catch (\Exception $throwable) {
             $this->_crashJob();
             throw $throwable;

--- a/src/Foreman.yml
+++ b/src/Foreman.yml
@@ -17,7 +17,6 @@ services:
       - [setApiV1WorkerService, ['@api.v1.worker.service']]
       - [setStateService, ['@state.service']]
       - [setMessageBroker, ['@message.broker.redis']]
-      - [setApmNewRelic, ['@apm.new_relic']]
   foreman:
     alias: neighborhoods.kojo.foreman
     public: false


### PR DESCRIPTION
**BREAKING CHANGE:** Current users could rely on the `Foreman` automatically starting and naming transactions, which will no longer be the case.

@alexberryman @danielbloom and I will have to modify our existing workers if we want that functionality

[FitnessFunction here](https://github.com/neighborhoods/KojoFitness/pull/13)