### PR TITLE
Declare ext-pcntl as composer.json dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     },
     "require": {
         "php": ">=7.1",
+        "ext-pcntl": "*",
         "symfony/filesystem": "^4.0",
         "symfony/config": "^4.0",
         "symfony/yaml": "^4.0",


### PR DESCRIPTION
This PR declares the `pcntl` extension as an explicit dependency in the composer.json file for this project. Useful for providing user feedback about whether this application is runnable in a given context.