### PR TITLE
Log a JsonSerializable object as context

### DIFF
--- a/src/Process/Pool/Logger.php
+++ b/src/Process/Pool/Logger.php
@@ -49,12 +49,13 @@ class Logger extends Log\AbstractLogger implements LoggerInterface
                 $logMessage->setProcessId($processId);
                 $logMessage->setProcessPath($this->_getProcess()->getPath());
                 $logMessage->setMessage($message);
-                if (count($context) === 1) {
-                    $contextValue = array_pop($context);
-                    if (is_object($contextValue) && $contextValue instanceof \JsonSerializable) {
-                        $logMessage->setContext($contextValue);
-                    }
+                if (json_encode($context) === false) {
+                    $logMessage->setContext([]);
+                } else {
+                    $logMessage->setContext($context);
                 }
+
+                $logMessage->setContextJsonLastError(json_last_error());
                 fwrite(STDOUT, $this->getLogFormatter()->getFormattedMessage($logMessage) . PHP_EOL);
             }
         }

--- a/src/Process/Pool/Logger.php
+++ b/src/Process/Pool/Logger.php
@@ -49,8 +49,11 @@ class Logger extends Log\AbstractLogger implements LoggerInterface
                 $logMessage->setProcessId($processId);
                 $logMessage->setProcessPath($this->_getProcess()->getPath());
                 $logMessage->setMessage($message);
-                if (count($context) === 1 && $context[0] instanceof \JsonSerializable) {
-                    $logMessage->setContext($context[0]);
+                if (count($context) === 1) {
+                    $contextValue = array_pop($context);
+                    if ($contextValue instanceof \JsonSerializable) {
+                        $logMessage->setContext($contextValue);
+                    }
                 }
                 fwrite(STDOUT, $this->getLogFormatter()->getFormattedMessage($logMessage) . PHP_EOL);
             }

--- a/src/Process/Pool/Logger.php
+++ b/src/Process/Pool/Logger.php
@@ -51,7 +51,7 @@ class Logger extends Log\AbstractLogger implements LoggerInterface
                 $logMessage->setMessage($message);
                 if (count($context) === 1) {
                     $contextValue = array_pop($context);
-                    if ($contextValue instanceof \JsonSerializable) {
+                    if (is_object($contextValue) && $contextValue instanceof \JsonSerializable) {
                         $logMessage->setContext($contextValue);
                     }
                 }

--- a/src/Process/Pool/Logger.php
+++ b/src/Process/Pool/Logger.php
@@ -49,8 +49,8 @@ class Logger extends Log\AbstractLogger implements LoggerInterface
                 $logMessage->setProcessId($processId);
                 $logMessage->setProcessPath($this->_getProcess()->getPath());
                 $logMessage->setMessage($message);
-                if (count($context) === 1 && $context instanceof \JsonSerializable) {
-                    $logMessage->setContext($context);
+                if (count($context) === 1 && $context[0] instanceof \JsonSerializable) {
+                    $logMessage->setContext($context[0]);
                 }
                 fwrite(STDOUT, $this->getLogFormatter()->getFormattedMessage($logMessage) . PHP_EOL);
             }

--- a/src/Process/Pool/Logger.php
+++ b/src/Process/Pool/Logger.php
@@ -49,7 +49,10 @@ class Logger extends Log\AbstractLogger implements LoggerInterface
                 $logMessage->setProcessId($processId);
                 $logMessage->setProcessPath($this->_getProcess()->getPath());
                 $logMessage->setMessage($message);
-                fwrite(STDOUT, $this->getLogFormatter()->getFormattedMessage($logMessage) . "\n");
+                if (count($context) === 1 && $context instanceof \JsonSerializable) {
+                    $logMessage->setContext($context);
+                }
+                fwrite(STDOUT, $this->getLogFormatter()->getFormattedMessage($logMessage) . PHP_EOL);
             }
         }
 

--- a/src/Process/Pool/Logger/Message.php
+++ b/src/Process/Pool/Logger/Message.php
@@ -150,7 +150,7 @@ class Message implements MessageInterface, \JsonSerializable
 
     protected function hasContext(): bool
     {
-        return ($this->context === null);
+        return !($this->context === null);
     }
 
     public function getContext(): \JsonSerializable

--- a/src/Process/Pool/Logger/Message.php
+++ b/src/Process/Pool/Logger/Message.php
@@ -17,6 +17,7 @@ class Message implements MessageInterface, \JsonSerializable
     protected $process_id;
     protected $process_path;
     protected $message;
+    protected $context;
 
     public function jsonSerialize(): array
     {
@@ -125,6 +126,26 @@ class Message implements MessageInterface, \JsonSerializable
         }
 
         $this->message = $message;
+
+        return $this;
+    }
+
+    public function getContext(): \JsonSerializable
+    {
+        if ($this->context === null) {
+            throw new \LogicException('Message context has not been set.');
+        }
+
+        return $this->context;
+    }
+
+    public function setContext(\JsonSerializable $context): MessageInterface
+    {
+        if ($this->context !== null) {
+            throw new \LogicException('Message context is already set.');
+        }
+
+        $this->context = $context;
 
         return $this;
     }

--- a/src/Process/Pool/Logger/Message.php
+++ b/src/Process/Pool/Logger/Message.php
@@ -22,13 +22,18 @@ class Message implements MessageInterface, \JsonSerializable
 
     public function jsonSerialize(): array
     {
+        $context = '';
+        if ($this->hasContext()) {
+            $context = $this->getContext();
+        }
+
         return [
             self::KEY_TIME => $this->getTime(),
             self::KEY_LEVEL => $this->getLevel(),
             self::KEY_PROCESS_ID => $this->getProcessId(),
             self::KEY_PROCESS_PATH => $this->getProcessPath(),
             self::KEY_MESSAGE => $this->getMessage(),
-            self::KEY_CONTEXT => $this->getContext(),
+            self::KEY_CONTEXT => $context,
         ];
     }
 
@@ -132,23 +137,28 @@ class Message implements MessageInterface, \JsonSerializable
         return $this;
     }
 
-    public function getContext(): \JsonSerializable
-    {
-        if ($this->context === null) {
-            throw new \LogicException('Message context has not been set.');
-        }
-
-        return $this->context;
-    }
-
     public function setContext(\JsonSerializable $context): MessageInterface
     {
-        if ($this->context !== null) {
+        if ($this->hasContext()) {
             throw new \LogicException('Message context is already set.');
         }
 
         $this->context = $context;
 
         return $this;
+    }
+
+    protected function hasContext(): bool
+    {
+        return ($this->context === null);
+    }
+
+    public function getContext(): \JsonSerializable
+    {
+        if ($this->hasContext()) {
+            throw new \LogicException('Message context has not been set.');
+        }
+
+        return $this->context;
     }
 }

--- a/src/Process/Pool/Logger/Message.php
+++ b/src/Process/Pool/Logger/Message.php
@@ -11,7 +11,6 @@ class Message implements MessageInterface, \JsonSerializable
     const KEY_PROCESS_ID = 'process_id';
     const KEY_PROCESS_PATH = 'process_path';
     const KEY_MESSAGE = 'message';
-    const KEY_CONTEXT = 'context';
 
     protected $time;
     protected $level;
@@ -19,22 +18,11 @@ class Message implements MessageInterface, \JsonSerializable
     protected $process_path;
     protected $message;
     protected $context;
+    protected $context_json_last_error;
 
     public function jsonSerialize(): array
     {
-        $context = '';
-        if ($this->hasContext()) {
-            $context = $this->getContext();
-        }
-
-        return [
-            self::KEY_TIME => $this->getTime(),
-            self::KEY_LEVEL => $this->getLevel(),
-            self::KEY_PROCESS_ID => $this->getProcessId(),
-            self::KEY_PROCESS_PATH => $this->getProcessPath(),
-            self::KEY_MESSAGE => $this->getMessage(),
-            self::KEY_CONTEXT => $context,
-        ];
+        return get_object_vars($this);
     }
 
     public function getTime(): string
@@ -137,7 +125,7 @@ class Message implements MessageInterface, \JsonSerializable
         return $this;
     }
 
-    public function setContext(\JsonSerializable $context): MessageInterface
+    public function setContext(array $context): MessageInterface
     {
         if ($this->context !== null) {
             throw new \LogicException('Message context is already set.');
@@ -148,17 +136,32 @@ class Message implements MessageInterface, \JsonSerializable
         return $this;
     }
 
-    protected function hasContext(): bool
-    {
-        return !($this->context === null);
-    }
-
-    public function getContext(): \JsonSerializable
+    public function getContext(): array
     {
         if ($this->context === null) {
             throw new \LogicException('Message context has not been set.');
         }
 
         return $this->context;
+    }
+
+    public function getContextJsonLastError(): int
+    {
+        if ($this->context_json_last_error === null) {
+            throw new \LogicException('Message context_json_last_error has not been set.');
+        }
+
+        return $this->context_json_last_error;
+    }
+
+    public function setContextJsonLastError(int $context_json_last_error): MessageInterface
+    {
+        if ($this->context_json_last_error !== null) {
+            throw new \LogicException('Message context_json_last_error is already set.');
+        }
+
+        $this->context_json_last_error = $context_json_last_error;
+
+        return $this;
     }
 }

--- a/src/Process/Pool/Logger/Message.php
+++ b/src/Process/Pool/Logger/Message.php
@@ -11,6 +11,7 @@ class Message implements MessageInterface, \JsonSerializable
     const KEY_PROCESS_ID = 'process_id';
     const KEY_PROCESS_PATH = 'process_path';
     const KEY_MESSAGE = 'message';
+    const KEY_CONTEXT = 'context';
 
     protected $time;
     protected $level;
@@ -27,6 +28,7 @@ class Message implements MessageInterface, \JsonSerializable
             self::KEY_PROCESS_ID => $this->getProcessId(),
             self::KEY_PROCESS_PATH => $this->getProcessPath(),
             self::KEY_MESSAGE => $this->getMessage(),
+            self::KEY_CONTEXT => $this->getContext(),
         ];
     }
 

--- a/src/Process/Pool/Logger/Message.php
+++ b/src/Process/Pool/Logger/Message.php
@@ -139,7 +139,7 @@ class Message implements MessageInterface, \JsonSerializable
 
     public function setContext(\JsonSerializable $context): MessageInterface
     {
-        if ($this->hasContext()) {
+        if ($this->context !== null) {
             throw new \LogicException('Message context is already set.');
         }
 
@@ -155,7 +155,7 @@ class Message implements MessageInterface, \JsonSerializable
 
     public function getContext(): \JsonSerializable
     {
-        if ($this->hasContext()) {
+        if ($this->context === null) {
             throw new \LogicException('Message context has not been set.');
         }
 

--- a/src/Process/Pool/Logger/MessageInterface.php
+++ b/src/Process/Pool/Logger/MessageInterface.php
@@ -6,27 +6,31 @@ namespace Neighborhoods\Kojo\Process\Pool\Logger;
 
 interface MessageInterface
 {
-    public function getTime() : string;
+    public function getTime(): string;
 
-    public function setTime(string $time) : MessageInterface;
+    public function setTime(string $time): MessageInterface;
 
-    public function getLevel() : string;
+    public function getLevel(): string;
 
-    public function setLevel(string $level) : MessageInterface;
+    public function setLevel(string $level): MessageInterface;
 
-    public function getProcessId() : string;
+    public function getProcessId(): string;
 
-    public function setProcessId(string $process_id) : MessageInterface;
+    public function setProcessId(string $process_id): MessageInterface;
 
-    public function getProcessPath() : string;
+    public function getProcessPath(): string;
 
-    public function setProcessPath(string $process_path) : MessageInterface;
+    public function setProcessPath(string $process_path): MessageInterface;
 
-    public function getMessage() : string;
+    public function getMessage(): string;
 
-    public function setMessage(string $message) : MessageInterface;
+    public function setMessage(string $message): MessageInterface;
 
-    public function setContext(\JsonSerializable $context): MessageInterface;
+    public function setContext(array $context): MessageInterface;
 
-    public function getContext(): \JsonSerializable;
+    public function getContext(): array;
+
+    public function getContextJsonLastError(): int;
+
+    public function setContextJsonLastError(int $context_json_last_error): MessageInterface;
 }

--- a/src/Process/Pool/Logger/MessageInterface.php
+++ b/src/Process/Pool/Logger/MessageInterface.php
@@ -6,7 +6,6 @@ namespace Neighborhoods\Kojo\Process\Pool\Logger;
 
 interface MessageInterface
 {
-
     public function getTime() : string;
 
     public function setTime(string $time) : MessageInterface;
@@ -26,4 +25,8 @@ interface MessageInterface
     public function getMessage() : string;
 
     public function setMessage(string $message) : MessageInterface;
+
+    public function setContext(\JsonSerializable $context): MessageInterface;
+
+    public function getContext(): \JsonSerializable;
 }


### PR DESCRIPTION
```php
$this->getApiV1WorkerService()->getLogger()->notice('MESSAGE', ['w00t!', 'p00t'=>'!']);
```
produces
```json
{
  "time": "Fri, 21 Dec 18 22:13:17.905085 UTC",
  "level": "notice",
  "process_id": "793",
  "process_path": "\/server[781]\/root[785]\/job[793]",
  "message": "MESSAGE",
  "context": {
    "0": "w00t!",
    "p00t": "!"
  },
  "context_json_last_error": 0
}
```

whilst
```php
$this->getApiV1WorkerService()->getLogger()->notice('MESSAGE', [NAN]);
```
produces
```json
{
  "time": "Fri, 21 Dec 18 21:45:26.754997 UTC",
  "level": "notice",
  "process_id": "742",
  "process_path": "\/server[734]\/root[738]\/job[742]",
  "message": "MESSAGE",
  "context": [
    
  ],
  "context_json_last_error": 7
}
```