### PR TITLE
Improve Throwable Logging

### DIFF
--- a/src/Foreman.php
+++ b/src/Foreman.php
@@ -87,9 +87,9 @@ class Foreman implements ForemanInterface
             $this->_injectWorkerService();
             $this->_injectRDBMSConnectionService();
             call_user_func($this->_getLocator()->getCallable());
-        } catch (\Throwable $throwable) {
+        } catch (\Exception $exception) {
             $this->_crashJob();
-            throw $throwable;
+            throw $exception;
         }
 
         return $this;

--- a/src/Foreman.php
+++ b/src/Foreman.php
@@ -87,7 +87,7 @@ class Foreman implements ForemanInterface
             $this->_injectWorkerService();
             $this->_injectRDBMSConnectionService();
             call_user_func($this->_getLocator()->getCallable());
-        } catch (\Exception $throwable) {
+        } catch (\Throwable $throwable) {
             $this->_crashJob();
             throw $throwable;
         }
@@ -101,10 +101,10 @@ class Foreman implements ForemanInterface
             $updateWork = $this->_getServiceUpdateWorkFactory()->create();
             $updateWork->setJob($this->_getJob());
             $updateWork->save();
-        } catch (\Exception $exception) {
+        } catch (\Throwable $throwable) {
             $this->_panicJob();
             $this->_getSemaphore()->releaseLock($this->_getNewJobOwnerResource($this->_getJob()));
-            throw $exception;
+            throw $throwable;
         }
 
         return $this;

--- a/src/Maintainer.php
+++ b/src/Maintainer.php
@@ -42,11 +42,11 @@ class Maintainer implements MaintainerInterface
             try {
                 $this->_rescheduleCrashedJobs();
                 $this->_getSemaphoreResource(self::SEMAPHORE_RESOURCE_NAME_RESCHEDULE_JOBS)->releaseLock();
-            } catch (\Exception $exception) {
+            } catch (\Throwable $throwable) {
                 if ($this->_getSemaphoreResource(self::SEMAPHORE_RESOURCE_NAME_RESCHEDULE_JOBS)->hasLock()) {
                     $this->_getSemaphoreResource(self::SEMAPHORE_RESOURCE_NAME_RESCHEDULE_JOBS)->releaseLock();
                 }
-                throw $exception;
+                throw $throwable;
             }
         }
 
@@ -69,11 +69,11 @@ class Maintainer implements MaintainerInterface
                     }
                     $jobSemaphoreResource->releaseLock();
                 }
-            } catch (\Exception $exception) {
+            } catch (\Throwable $throwable) {
                 if ($jobSemaphoreResource->hasLock()) {
                     $jobSemaphoreResource->releaseLock();
                 }
-                throw $exception;
+                throw $throwable;
             }
         }
 
@@ -86,11 +86,11 @@ class Maintainer implements MaintainerInterface
             try {
                 $this->_updatePendingJobs();
                 $this->_getSemaphoreResource(self::SEMAPHORE_RESOURCE_NAME_UPDATE_PENDING_JOBS)->releaseLock();
-            } catch (\Exception $exception) {
+            } catch (\Throwable $throwable) {
                 if ($this->_getSemaphoreResource(self::SEMAPHORE_RESOURCE_NAME_UPDATE_PENDING_JOBS)->hasLock()) {
                     $this->_getSemaphoreResource(self::SEMAPHORE_RESOURCE_NAME_UPDATE_PENDING_JOBS)->releaseLock();
                 }
-                throw $exception;
+                throw $throwable;
             }
         }
 
@@ -115,7 +115,7 @@ class Maintainer implements MaintainerInterface
                     $failedLimitCheckUpdate->setJob($job);
                     $failedLimitCheckUpdate->save();
                 }
-            } catch (\Exception $exception) {
+            } catch (\Throwable $throwable) {
                 $updatePanic = $this->_getServiceUpdatePanicFactory()->create();
                 $updatePanic->setJob($job);
                 $updatePanic->save();

--- a/src/Maintainer/Delete.php
+++ b/src/Maintainer/Delete.php
@@ -25,11 +25,11 @@ class Delete implements DeleteInterface
             try {
                 $this->_deleteCompletedJobs();
                 $this->_getSemaphoreResource(self::SEMAPHORE_RESOURCE_NAME_MAINTAINER_DELETE)->releaseLock();
-            } catch (\Exception $exception) {
+            } catch (\Throwable $throwable) {
                 if ($this->_getSemaphoreResource(self::SEMAPHORE_RESOURCE_NAME_MAINTAINER_DELETE)->hasLock()) {
                     $this->_getSemaphoreResource(self::SEMAPHORE_RESOURCE_NAME_MAINTAINER_DELETE)->releaseLock();
                 }
-                throw $exception;
+                throw $throwable;
             }
         }
 

--- a/src/Message/Broker/Redis.php
+++ b/src/Message/Broker/Redis.php
@@ -20,9 +20,9 @@ class Redis extends BrokerAbstract
                 $this->_getSubscriptionChannelName(),
                 0
             );
-        }catch(\Exception $exception){
-            $this->_getLogger()->critical($exception->getMessage());
-            throw $exception;
+        }catch(\Throwable $throwable){
+            $this->_getLogger()->critical($throwable->getMessage(), [$throwable->__toString()]);
+            throw $throwable;
         }
 
         return $this;
@@ -42,9 +42,9 @@ class Redis extends BrokerAbstract
         try{
             $publishChannelLength = $this->getPublishChannelLength();
             $subscriptionChannelLength = $this->getSubscriptionChannelLength();
-        }catch(\Exception $exception){
-            $this->_getLogger()->critical($exception->getMessage());
-            throw $exception;
+        }catch(\Throwable $throwable){
+            $this->_getLogger()->critical($throwable->getMessage(), [$throwable->__toString()]);
+            throw $throwable;
         }
 
         return $publishChannelLength + $subscriptionChannelLength > 0 ? true : false;
@@ -57,9 +57,9 @@ class Redis extends BrokerAbstract
             if ($message === false) {
                 $message = $this->_getRedisClient()->rPop($this->_getPublishChannelName());
             }
-        }catch(\Exception $exception){
-            $this->_getLogger()->critical($exception->getMessage());
-            throw $exception;
+        }catch(\Throwable $throwable){
+            $this->_getLogger()->critical($throwable->getMessage(), [$throwable->__toString()]);
+            throw $throwable;
         }
 
         return (string)$message;
@@ -69,9 +69,9 @@ class Redis extends BrokerAbstract
     {
         try{
             $publishChannelLength = $this->_getRedisClient()->lLen($this->_getPublishChannelName());
-        }catch(\Exception $exception){
-            $this->_getLogger()->critical($exception->getMessage());
-            throw $exception;
+        }catch(\Throwable $throwable){
+            $this->_getLogger()->critical($throwable->getMessage(), [$throwable->__toString()]);
+            throw $throwable;
         }
 
         return $publishChannelLength;
@@ -81,9 +81,9 @@ class Redis extends BrokerAbstract
     {
         try{
             $subscriptionChannelLength = $this->_getRedisClient()->lLen($this->_getSubscriptionChannelName());
-        }catch(\Exception $exception){
-            $this->_getLogger()->critical($exception->getMessage());
-            throw $exception;
+        }catch(\Throwable $throwable){
+            $this->_getLogger()->critical($throwable->getMessage(), [$throwable->__toString()]);
+            throw $throwable;
         }
 
         return $subscriptionChannelLength;
@@ -93,9 +93,9 @@ class Redis extends BrokerAbstract
     {
         try{
             $this->_getRedisClient()->lPush($this->_getPublishChannelName(), $message);
-        }catch(\Exception $exception){
-            $this->_getLogger()->critical($exception->getMessage());
-            throw $exception;
+        }catch(\Throwable $throwable){
+            $this->_getLogger()->critical($throwable->getMessage(), [$throwable->__toString()]);
+            throw $throwable;
         }
 
         return $this;

--- a/src/Message/Broker/Redis.php
+++ b/src/Message/Broker/Redis.php
@@ -14,14 +14,14 @@ class Redis extends BrokerAbstract
 
     public function waitForNewMessage(): BrokerInterface
     {
-        try{
+        try {
             $this->_getRedisClient()->brpoplpush(
                 $this->_getPublishChannelName(),
                 $this->_getSubscriptionChannelName(),
                 0
             );
-        }catch(\Throwable $throwable){
-            $this->_getLogger()->critical($throwable->getMessage(), [$throwable->__toString()]);
+        } catch (\Throwable $throwable) {
+            $this->_getLogger()->critical($throwable->getMessage(), [(string)$throwable]);
             throw $throwable;
         }
 
@@ -39,11 +39,11 @@ class Redis extends BrokerAbstract
 
     public function hasMessage(): bool
     {
-        try{
+        try {
             $publishChannelLength = $this->getPublishChannelLength();
             $subscriptionChannelLength = $this->getSubscriptionChannelLength();
-        }catch(\Throwable $throwable){
-            $this->_getLogger()->critical($throwable->getMessage(), [$throwable->__toString()]);
+        } catch (\Throwable $throwable) {
+            $this->_getLogger()->critical($throwable->getMessage(), [(string)$throwable]);
             throw $throwable;
         }
 
@@ -52,13 +52,13 @@ class Redis extends BrokerAbstract
 
     public function getNextMessage(): string
     {
-        try{
+        try {
             $message = $this->_getRedisClient()->lPop($this->_getSubscriptionChannelName());
             if ($message === false) {
                 $message = $this->_getRedisClient()->rPop($this->_getPublishChannelName());
             }
-        }catch(\Throwable $throwable){
-            $this->_getLogger()->critical($throwable->getMessage(), [$throwable->__toString()]);
+        } catch (\Throwable $throwable) {
+            $this->_getLogger()->critical($throwable->getMessage(), [(string)$throwable]);
             throw $throwable;
         }
 
@@ -67,10 +67,10 @@ class Redis extends BrokerAbstract
 
     public function getPublishChannelLength(): int
     {
-        try{
+        try {
             $publishChannelLength = $this->_getRedisClient()->lLen($this->_getPublishChannelName());
-        }catch(\Throwable $throwable){
-            $this->_getLogger()->critical($throwable->getMessage(), [$throwable->__toString()]);
+        } catch (\Throwable $throwable) {
+            $this->_getLogger()->critical($throwable->getMessage(), [(string)$throwable]);
             throw $throwable;
         }
 
@@ -79,10 +79,10 @@ class Redis extends BrokerAbstract
 
     public function getSubscriptionChannelLength(): int
     {
-        try{
+        try {
             $subscriptionChannelLength = $this->_getRedisClient()->lLen($this->_getSubscriptionChannelName());
-        }catch(\Throwable $throwable){
-            $this->_getLogger()->critical($throwable->getMessage(), [$throwable->__toString()]);
+        } catch (\Throwable $throwable) {
+            $this->_getLogger()->critical($throwable->getMessage(), [(string)$throwable]);
             throw $throwable;
         }
 
@@ -91,10 +91,10 @@ class Redis extends BrokerAbstract
 
     public function publishMessage($message): BrokerInterface
     {
-        try{
+        try {
             $this->_getRedisClient()->lPush($this->_getPublishChannelName(), $message);
-        }catch(\Throwable $throwable){
-            $this->_getLogger()->critical($throwable->getMessage(), [$throwable->__toString()]);
+        } catch (\Throwable $throwable) {
+            $this->_getLogger()->critical($throwable->getMessage(), [(string)$throwable]);
             throw $throwable;
         }
 

--- a/src/Process/Job.php
+++ b/src/Process/Job.php
@@ -27,8 +27,7 @@ class Job extends Forked implements JobInterface
             $this->_getMaintainer()->deleteCompletedJobs();
             $this->_getForeman()->workWorker();
         } catch (\Throwable $throwable) {
-            $message = $this->_getLogger()->getLogFormatter()->getFormattedThrowableMessage($throwable);
-            $this->_getLogger()->critical($message);
+            $this->_getLogger()->critical($throwable->getMessage(), [$throwable->__toString()]);
             $this->_setOrReplaceExitCode(255);
         }
 

--- a/src/Process/Job.php
+++ b/src/Process/Job.php
@@ -27,7 +27,7 @@ class Job extends Forked implements JobInterface
             $this->_getMaintainer()->deleteCompletedJobs();
             $this->_getForeman()->workWorker();
         } catch (\Throwable $throwable) {
-            $this->_getLogger()->critical($throwable->getMessage(), [$throwable->__toString()]);
+            $this->_getLogger()->critical($throwable->getMessage(), [(string)$throwable]);
             $this->_setOrReplaceExitCode(255);
         }
 

--- a/src/Process/Pool/Logger/FormatterInterface.php
+++ b/src/Process/Pool/Logger/FormatterInterface.php
@@ -15,5 +15,6 @@ interface FormatterInterface
 
     public function setLogFormat(string $logFormat);
 
+    /** @deprecated Use the \Throwable's __toString() method as the message and/or context instead. */
     public function getFormattedThrowableMessage(\Throwable $throwable) : string;
 }

--- a/src/Process/Pool/Logger/FormatterInterface.php
+++ b/src/Process/Pool/Logger/FormatterInterface.php
@@ -7,14 +7,16 @@ namespace Neighborhoods\Kojo\Process\Pool\Logger;
 
 interface FormatterInterface
 {
-    public function getFormattedMessage(MessageInterface $message) : string;
+    public function getFormattedMessage(MessageInterface $message): string;
 
-    public function setProcessPathPadding(int $processPathPadding) : FormatterInterface;
+    public function setProcessPathPadding(int $processPathPadding): FormatterInterface;
 
-    public function setProcessIdPadding(int $processIdPadding) : FormatterInterface;
+    public function setProcessIdPadding(int $processIdPadding): FormatterInterface;
 
     public function setLogFormat(string $logFormat);
 
-    /** @deprecated Use the \Throwable's __toString() method as the message and/or context instead. */
-    public function getFormattedThrowableMessage(\Throwable $throwable) : string;
+    /**
+     * @deprecated Use the \Throwable's __toString() method (or cast as a string) as the message and/or context instead.
+     */
+    public function getFormattedThrowableMessage(\Throwable $throwable): string;
 }

--- a/src/Scheduler.php
+++ b/src/Scheduler.php
@@ -27,11 +27,11 @@ class Scheduler implements SchedulerInterface
                     $this->_scheduleStaticJobs();
                 }
                 $this->_getSemaphoreResource(self::SEMAPHORE_RESOURCE_NAME_SCHEDULE)->releaseLock();
-            }catch(\Exception $exception){
+            }catch(\Throwable $throwable){
                 if ($this->_getSemaphoreResource(self::SEMAPHORE_RESOURCE_NAME_SCHEDULE)->hasLock()) {
                     $this->_getSemaphoreResource(self::SEMAPHORE_RESOURCE_NAME_SCHEDULE)->releaseLock();
                 }
-                throw $exception;
+                throw $throwable;
             }
         }
 

--- a/src/Scheduler.php
+++ b/src/Scheduler.php
@@ -22,12 +22,12 @@ class Scheduler implements SchedulerInterface
     public function scheduleStaticJobs(): SchedulerInterface
     {
         if ($this->_getSemaphoreResource(self::SEMAPHORE_RESOURCE_NAME_SCHEDULE)->testAndSetLock()) {
-            try{
+            try {
                 if (!empty($this->_getSchedulerCache()->getMinutesNotInCache())) {
                     $this->_scheduleStaticJobs();
                 }
                 $this->_getSemaphoreResource(self::SEMAPHORE_RESOURCE_NAME_SCHEDULE)->releaseLock();
-            }catch(\Throwable $throwable){
+            } catch (\Throwable $throwable) {
                 if ($this->_getSemaphoreResource(self::SEMAPHORE_RESOURCE_NAME_SCHEDULE)->hasLock()) {
                     $this->_getSemaphoreResource(self::SEMAPHORE_RESOURCE_NAME_SCHEDULE)->releaseLock();
                 }


### PR DESCRIPTION
* Catch Throwables instead of Exceptions.
* Use the Throwable message as the logged message.
* Use the Throwable __toString method as the logged context.
* Deprecate `Logger\FormatterInterface::getFormattedThrowableMessage`