### PR TITLE
Fixes to signal handling, updates to logging, add error handler, handle fork fault (OOM), disable signal buffering for non-reactive Procs 

### DIFF
--- a/bin/kojo
+++ b/bin/kojo
@@ -3,27 +3,17 @@
 declare(strict_types=1);
 ini_set('assert.exception', '1');
 error_reporting(E_ALL);
+require_once __DIR__ . '/../../../../vendor/autoload.php';
 
 use Neighborhoods\Kojo\Console\Command\Process\Pool\Server\Start;
+use Neighborhoods\Kojo\ErrorHandler;
 use Neighborhoods\Pylon\DependencyInjection\ContainerBuilder\Facade;
 use Symfony\Component\Finder\Finder;
 
+set_error_handler(new ErrorHandler());
+
 if (PHP_SAPI !== 'cli') {
     echo 'bin/kojo must be run as a CLI application';
-    exit(1);
-}
-try{
-    foreach ([
-                 __DIR__ . '/../../../autoload.php',
-                 __DIR__ . '/../vendor/autoload.php',
-             ] as $autoLoaderFilePathCandidate) {
-        if (file_exists($autoLoaderFilePathCandidate)) {
-            require_once $autoLoaderFilePathCandidate;
-            break;
-        }
-    }
-}catch(\Exception $exception){
-    echo 'Autoload error: ' . $exception->getMessage();
     exit(1);
 }
 $containerBuilderFacade = new Facade();
@@ -32,7 +22,7 @@ $finder = new Finder();
 $finder->name('*.yml');
 if (isset($argv[2]) && is_string($argv[2]) && is_dir($argv[2])) {
     $discoverableDirectories[] = $argv[2];
-}elseif (isset($argv[1]) && is_string($argv[1]) && $argv[1] === Start::OPT_RUN_SERVER) {
+} elseif (isset($argv[1]) && is_string($argv[1]) && $argv[1] === Start::OPT_RUN_SERVER) {
     foreach ($argv as $argument) {
         if (strstr($argument, Start::OPT_YSDP) !== false) {
             $ymlServicesFilePath = explode(Start::OPT_YSDP, $argument);

--- a/pylon/src/DependencyInjection/ContainerBuilder/Facade.php
+++ b/pylon/src/DependencyInjection/ContainerBuilder/Facade.php
@@ -7,8 +7,8 @@ use Neighborhoods\Pylon\Symfony\Component\FinderArray;
 use Neighborhoods\Pylon\Symfony\Component\FinderArrayInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Compiler\RepeatedPass;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+
 use Symfony\Component\DependencyInjection\Compiler\AnalyzeServiceReferencesPass;
 use Symfony\Component\DependencyInjection\Compiler\InlineServiceDefinitionsPass;
 use Symfony\Component\Finder\Finder;
@@ -56,9 +56,8 @@ class Facade implements FacadeInterface
             foreach ($this->_getYamlServicesFilePaths() as $servicesYmlFilePath) {
                 $loader->import($servicesYmlFilePath);
             }
-            $passes = [new AnalyzeServiceReferencesPass(), new InlineServiceDefinitionsPass()];
-            $repeatedPass = new RepeatedPass($passes);
-            $repeatedPass->process($containerBuilder);
+            $containerBuilder->addCompilerPass(new AnalyzeServiceReferencesPass());
+            $containerBuilder->addCompilerPass(new InlineServiceDefinitionsPass());
             $containerBuilder->compile(true);
             $this->_containerBuilder = $containerBuilder;
         }

--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Kojo;
+
+class ErrorHandler implements ErrorHandlerInterface
+{
+    public function __invoke(
+        int $errorNumber,
+        string $errorString,
+        string $errorFile,
+        int $errorLine
+    ): ErrorHandlerInterface {
+        throw new \ErrorException($errorString, $errorNumber, $errorNumber, $errorFile, $errorLine);
+    }
+}

--- a/src/ErrorHandlerInterface.php
+++ b/src/ErrorHandlerInterface.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Kojo;
+
+interface ErrorHandlerInterface
+{
+    public function __invoke(
+        int $errorNumber,
+        string $errorString,
+        string $errorFile,
+        int $errorLine
+    );
+}

--- a/src/Foreman.php
+++ b/src/Foreman.php
@@ -9,7 +9,6 @@ use Neighborhoods\Kojo\Service\Update;
 use Neighborhoods\Kojo\Worker\Locator;
 use Neighborhoods\Kojo\Process\Pool\Logger;
 use Neighborhoods\Pylon\Data\Property\Defensive;
-use Neighborhoods\Kojo\Apm;
 
 class Foreman implements ForemanInterface
 {
@@ -84,10 +83,13 @@ class Foreman implements ForemanInterface
     protected function _runWorker(): ForemanInterface
     {
         try {
+            restore_error_handler();
             $this->_injectWorkerService();
             $this->_injectRDBMSConnectionService();
             call_user_func($this->_getLocator()->getCallable());
+            set_error_handler(new ErrorHandler());
         } catch (\Exception $exception) {
+            set_error_handler(new ErrorHandler());
             $this->_crashJob();
             throw $exception;
         }

--- a/src/Process/Forked.php
+++ b/src/Process/Forked.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Neighborhoods\Kojo\Process;
 
+use Neighborhoods\Kojo\Process\Forked\Exception;
 use Neighborhoods\Kojo\ProcessAbstract;
 use Neighborhoods\Kojo\ProcessInterface;
 
@@ -16,7 +17,7 @@ abstract class Forked extends ProcessAbstract implements ProcessInterface
         $this->_create(self::PROP_HAS_FORKED, true);
         $processId = $this->_getProcessStrategy()->fork();
         if ($processId === self::FORK_FAILURE_CODE) {
-            throw new \RuntimeException('Failed to fork a new process.');
+            throw (new Exception())->setCode(Exception::CODE_FORK_FAILED);
         } elseif ($processId > 0) {
             // This is executed in the parent process.
             $this->_setProcessId($processId);

--- a/src/Process/Forked.php
+++ b/src/Process/Forked.php
@@ -9,7 +9,7 @@ use Neighborhoods\Kojo\ProcessInterface;
 abstract class Forked extends ProcessAbstract implements ProcessInterface
 {
     const FORK_FAILURE_CODE = -1;
-    const PROP_HAS_FORKED   = 'has_forked';
+    const PROP_HAS_FORKED = 'has_forked';
 
     public function start(): ProcessInterface
     {
@@ -17,13 +17,12 @@ abstract class Forked extends ProcessAbstract implements ProcessInterface
         $processId = $this->_getProcessStrategy()->fork();
         if ($processId === self::FORK_FAILURE_CODE) {
             throw new \RuntimeException('Failed to fork a new process.');
-        }elseif ($processId > 0) {
+        } elseif ($processId > 0) {
             // This is executed in the parent process.
             $this->_setProcessId($processId);
-        }else {
+        } else {
             // This is executed in the child process.
             $this->_initialize();
-            $this->_getProcessSignal()->decrementWaitCount();
             $this->_getProcessPool()->start();
             $this->_run();
             $this->exit();

--- a/src/Process/Forked/Exception.php
+++ b/src/Process/Forked/Exception.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Kojo\Process\Forked;
+
+use Neighborhoods\Kojo\Runtime;
+
+class Exception extends Runtime\Exception
+{
+    public const CODE_FORK_FAILED = self::CODE_PREFIX . 'fork_failed';
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->addPossibleMessage(self::CODE_FORK_FAILED, 'Failed to fork a new process.');
+
+        return $this;
+    }
+}

--- a/src/Process/Job.php
+++ b/src/Process/Job.php
@@ -20,6 +20,7 @@ class Job extends Forked implements JobInterface
     protected function _run(): Forked
     {
         try {
+            $this->_getProcessSignal()->setCanBufferSignals(false);
             $this->_getSelector()->setProcess($this);
             $this->_getMaintainer()->rescheduleCrashedJobs();
             $this->_getScheduler()->scheduleStaticJobs();

--- a/src/Process/Job.php
+++ b/src/Process/Job.php
@@ -17,7 +17,7 @@ class Job extends Forked implements JobInterface
     use Selector\AwareTrait;
     use Process\Pool\Factory\AwareTrait;
 
-    protected function _run() : Forked
+    protected function _run(): Forked
     {
         try {
             $this->_getSelector()->setProcess($this);

--- a/src/Process/Listener/Mutex/Redis.php
+++ b/src/Process/Listener/Mutex/Redis.php
@@ -16,6 +16,7 @@ class Redis extends ListenerAbstract implements RedisInterface
 
     protected function _run(): Forked
     {
+        $this->_getProcessSignal()->setCanBufferSignals(false);
         $this->_register();
 
         return $this;

--- a/src/Process/Pool.php
+++ b/src/Process/Pool.php
@@ -22,23 +22,16 @@ class Pool extends PoolAbstract implements PoolInterface
 
     public function handleSignal(InformationInterface $signalInformation): HandlerInterface
     {
-        try {
-            $this->_getProcessSignal()->incrementWaitCount();
-            $signalNumber = $signalInformation->getSignalNumber();
-            switch ($signalNumber) {
-                case SIGCHLD:
-                    $this->_childExitSignal($signalInformation);
-                    break;
-                case SIGALRM:
-                    $this->_alarmSignal($signalInformation);
-                    break;
-                default:
-                    throw new \UnexpectedValueException("Unexpected signal number[$signalNumber].");
-            }
-            $this->_getProcessSignal()->decrementWaitCount();
-        } catch (\Throwable $throwable) {
-            $this->_getProcessSignal()->decrementWaitCount();
-            throw $throwable;
+        $signalNumber = $signalInformation->getSignalNumber();
+        switch ($signalNumber) {
+            case SIGCHLD:
+                $this->_childExitSignal($signalInformation);
+                break;
+            case SIGALRM:
+                $this->_alarmSignal($signalInformation);
+                break;
+            default:
+                throw new \UnexpectedValueException("Unexpected signal number[$signalNumber].");
         }
 
         return $this;
@@ -63,24 +56,17 @@ class Pool extends PoolAbstract implements PoolInterface
 
     public function freeChildProcess(int $childProcessId): PoolInterface
     {
-        try {
-            $this->_getProcessSignal()->incrementWaitCount();
-            if (isset($this->_childProcesses[$childProcessId])) {
-                if ($this->_childProcesses[$childProcessId] instanceof ProcessInterface) {
-                    $typeCode = $this->_childProcesses[$childProcessId]->getTypeCode();
-                    $this->_getLogger()->info("Freeing child process related to process[$childProcessId][$typeCode].");
-                    unset($this->_childProcesses[$childProcessId]);
-                } else {
-                    $message = "Process associated to process[$childProcessId] is not an expected type.";
-                    throw new \UnexpectedValueException($message);
-                }
+        if (isset($this->_childProcesses[$childProcessId])) {
+            if ($this->_childProcesses[$childProcessId] instanceof ProcessInterface) {
+                $typeCode = $this->_childProcesses[$childProcessId]->getTypeCode();
+                $this->_getLogger()->debug("Freeing child process related to process[$childProcessId][$typeCode].");
+                unset($this->_childProcesses[$childProcessId]);
             } else {
-                throw new \LogicException("Process associated to process[$childProcessId] is not in the process pool.");
+                $message = "Process associated to process[$childProcessId] is not an expected type.";
+                throw new \UnexpectedValueException($message);
             }
-            $this->_getProcessSignal()->decrementWaitCount();
-        } catch (\Throwable $throwable) {
-            $this->_getProcessSignal()->decrementWaitCount();
-            throw $throwable;
+        } else {
+            throw new \LogicException("Process associated to process[$childProcessId] is not in the process pool.");
         }
 
         return $this;
@@ -93,20 +79,13 @@ class Pool extends PoolAbstract implements PoolInterface
 
     public function addChildProcess(ProcessInterface $childProcess): PoolInterface
     {
-        try {
-            $this->_getProcessSignal()->incrementWaitCount();
-            if ($this->isFull()) {
-                throw new \LogicException('Process pool is full.');
-            } else {
-                $childProcess->start();
-                $this->_childProcesses[$childProcess->getProcessId()] = $childProcess;
-                $message = "Forked process[{$childProcess->getProcessId()}][{$childProcess->getTypeCode()}].";
-                $this->_getLogger()->info($message);
-            }
-            $this->_getProcessSignal()->decrementWaitCount();
-        } catch (\Throwable $throwable) {
-            $this->_getProcessSignal()->decrementWaitCount();
-            throw $throwable;
+        if ($this->isFull()) {
+            throw new \LogicException('Process pool is full.');
+        } else {
+            $childProcess->start();
+            $this->_childProcesses[$childProcess->getProcessId()] = $childProcess;
+            $message = "Forked process[{$childProcess->getProcessId()}][{$childProcess->getTypeCode()}].";
+            $this->_getLogger()->debug($message);
         }
 
         return $this;
@@ -114,24 +93,16 @@ class Pool extends PoolAbstract implements PoolInterface
 
     public function getChildProcess(int $childProcessId): ProcessInterface
     {
-        try {
-            $this->_getProcessSignal()->incrementWaitCount();
-            if (!isset($this->_childProcesses[$childProcessId])) {
-                throw new \LogicException("Process with process ID[$childProcessId] not set.");
-            }
-            $childProcess = $this->_childProcesses[$childProcessId];
-            $this->_getProcessSignal()->decrementWaitCount();
-        } catch (\Throwable $throwable) {
-            $this->_getProcessSignal()->decrementWaitCount();
-            throw $throwable;
+        if (!isset($this->_childProcesses[$childProcessId])) {
+            throw new \LogicException("Process with process ID[$childProcessId] not set.");
         }
+        $childProcess = $this->_childProcesses[$childProcessId];
 
         return $childProcess;
     }
 
     public function terminateChildProcesses(): PoolInterface
     {
-        $this->_getProcessSignal()->block();
         if (!empty($this->_childProcesses)) {
             /** @var ProcessInterface $process */
             foreach ($this->_childProcesses as $process) {
@@ -139,8 +110,14 @@ class Pool extends PoolAbstract implements PoolInterface
                 $terminationSignalNumber = $process->getTerminationSignalNumber();
                 $processTypeCode = $process->getTypeCode();
                 posix_kill($processId, $terminationSignalNumber);
-                $message = "Sent kill($terminationSignalNumber) to process[$processId][$processTypeCode].";
-                $this->_getLogger()->info($message);
+                $this->_getLogger()->debug(
+                    sprintf(
+                        'Sent kill[%s] to process[%s][%s].',
+                        $terminationSignalNumber,
+                        $processId,
+                        $processTypeCode
+                    )
+                );
                 unset($this->_childProcesses[$processId]);
             }
         }

--- a/src/Process/Pool/Server.php
+++ b/src/Process/Pool/Server.php
@@ -23,7 +23,7 @@ class Server extends ProcessAbstract implements ServerInterface
         $this->_initialize();
         $this->_getLogger()->debug('Starting process pool server...');
         if ($this->_getSemaphore()->testAndSetLock($this->_getServerSemaphoreResource())) {
-            $this->_getLogger()->info('Process pool server started.');
+            $this->_getLogger()->debug('Process pool server started.');
             $this->_getProcessPool()->start();
             while (true) {
                 $this->_getProcessSignal()->processBufferedSignals();

--- a/src/Process/Pool/Server.php
+++ b/src/Process/Pool/Server.php
@@ -26,9 +26,10 @@ class Server extends ProcessAbstract implements ServerInterface
             $this->_getLogger()->info('Process pool server started.');
             $this->_getProcessPool()->start();
             while (true) {
-                $this->_getProcessSignal()->waitForSignal();
+                $this->_getProcessSignal()->processBufferedSignals();
+                sleep(1);
             }
-        }else {
+        } else {
             $this->_getLogger()->debug('Cannot obtain the process pool server mutex. Quitting.');
             $this->exit();
         }

--- a/src/Process/Pool/Strategy.php
+++ b/src/Process/Pool/Strategy.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Neighborhoods\Kojo\Process\Pool;
 
+use Neighborhoods\Kojo\Process\Forked\Exception;
+use Neighborhoods\Kojo\Process\Listener\CommandInterface;
 use Neighborhoods\Kojo\ProcessInterface;
 use Neighborhoods\Kojo\Process\JobInterface;
 use Neighborhoods\Kojo\Process\ListenerInterface;
@@ -15,9 +17,9 @@ class Strategy extends StrategyAbstract
     {
         if ($process instanceof JobInterface) {
             $this->_jobProcessExited($process);
-        }elseif ($process instanceof ListenerInterface) {
+        } elseif ($process instanceof ListenerInterface) {
             $this->_listenerProcessExited($process);
-        }else {
+        } else {
             $className = get_class($process);
             throw new \UnexpectedValueException("Unexpected process class[$className].");
         }
@@ -29,7 +31,7 @@ class Strategy extends StrategyAbstract
     {
         if ($listenerProcess->getExitCode() !== 0) {
             $this->_pauseListenerProcess($listenerProcess);
-        }else {
+        } else {
             while (
                 $listenerProcess->hasMessages()
                 && !$this->_getProcessPool()->isFull()
@@ -40,11 +42,16 @@ class Strategy extends StrategyAbstract
 
             if ($this->_getProcessPool()->isFull()) {
                 $this->_pauseListenerProcess($listenerProcess);
-            }else {
+            } else {
                 $this->_getProcessPool()->freeChildProcess($listenerProcess->getProcessId());
                 $typeCode = $listenerProcess->getTypeCode();
                 $replacementListenerProcess = $this->_getProcessCollection()->getProcessPrototypeClone($typeCode);
-                $this->_getProcessPool()->addChildProcess($replacementListenerProcess);
+                try {
+                    $this->_getProcessPool()->addChildProcess($replacementListenerProcess);
+                } catch (Exception $forkedException) {
+                    $this->_pauseListenerProcess($listenerProcess);
+                    $this->_getLogger()->critical($forkedException->getMessage(), [(string)$forkedException]);
+                }
             }
         }
 
@@ -59,7 +66,7 @@ class Strategy extends StrategyAbstract
     {
         if ($this->_hasPausedListenerProcess()) {
             $this->_unPauseListenerProcesses();
-        }else {
+        } else {
             if (!$this->_getProcessPool()->hasAlarm()) {
                 $this->_getProcessPool()->setAlarm($this->getMaxAlarmTime());
             }
@@ -75,7 +82,11 @@ class Strategy extends StrategyAbstract
             $typeCode = $jobProcess->getTypeCode();
             $replacementProcess = $this->_getProcessCollection()->getProcessPrototypeClone($typeCode);
             $replacementProcess->setThrottle($this->getChildProcessWaitThrottle());
-            $this->_getProcessPool()->addChildProcess($replacementProcess);
+            try {
+                $this->_getProcessPool()->addChildProcess($replacementProcess);
+            } catch (Exception $forkedException) {
+                $this->_getLogger()->critical($forkedException->getMessage(), [(string)$forkedException]);
+            }
             if (!$this->_getProcessPool()->hasAlarm()) {
                 $this->_getProcessPool()->setAlarm($this->getMaxAlarmTime());
             }
@@ -89,10 +100,14 @@ class Strategy extends StrategyAbstract
         if (!$this->_getProcessPool()->isFull() && $this->_getProcessPool()->canEnvironmentSustainAdditionProcesses()) {
             if ($this->_hasPausedListenerProcess()) {
                 $this->_unPauseListenerProcesses();
-            }else {
+            } else {
                 $alarmProcessTypeCode = $this->_getAlarmProcessTypeCode();
                 $alarmProcess = $this->_getProcessCollection()->getProcessPrototypeClone($alarmProcessTypeCode);
-                $this->_getProcessPool()->addChildProcess($alarmProcess);
+                try {
+                    $this->_getProcessPool()->addChildProcess($alarmProcess);
+                } catch (Exception $forkedException) {
+                    $this->_getLogger()->critical($forkedException->getMessage(), [(string)$forkedException]);
+                }
             }
         }
         if (!$this->_getProcessPool()->hasAlarm()) {
@@ -107,13 +122,24 @@ class Strategy extends StrategyAbstract
         $this->_getProcessPool()->setAlarm($this->getMaxAlarmTime());
         $this->_getProcessCollection()->applyProcessPool($this->_getProcessPool());
         foreach ($this->_getProcessCollection() as $process) {
-            $this->_getProcessPool()->addChildProcess($process);
+            try {
+                $this->_getProcessPool()->addChildProcess($process);
+            } catch (Exception $forkedException) {
+                $this->_getLogger()->critical($forkedException->getMessage(), [(string)$forkedException]);
+                if ($process instanceof CommandInterface) {
+                    $this->_getProcessPool()->getProcess()->exit();
+                }
+            }
         }
         if ($this->_hasFillProcessTypeCode() && $this->_getProcessPool()->canEnvironmentSustainAdditionProcesses()) {
             while (!$this->_getProcessPool()->isFull()) {
                 $fillProcessTypeCode = $this->_getFillProcessTypeCode();
                 $fillProcess = $this->_getProcessCollection()->getProcessPrototypeClone($fillProcessTypeCode);
-                $this->_getProcessPool()->addChildProcess($fillProcess);
+                try {
+                    $this->_getProcessPool()->addChildProcess($fillProcess);
+                } catch (Exception $forkedException) {
+                    $this->_getLogger()->critical($forkedException->getMessage(), [(string)$forkedException]);
+                }
             }
         }
 
@@ -126,7 +152,7 @@ class Strategy extends StrategyAbstract
         if (!isset($this->_pausedListenerProcesses[$listenerProcessId])) {
             $this->_getProcessPool()->freeChildProcess($listenerProcessId);
             $this->_pausedListenerProcesses[$listenerProcessId] = $listenerProcess;
-        }else {
+        } else {
             throw new \LogicException('Listener process is already paused.');
         }
 
@@ -149,14 +175,18 @@ class Strategy extends StrategyAbstract
                         $listenerProcess->processMessages();
                     }
                     if (!$this->_getProcessPool()->isFull()) {
-                        unset($this->_pausedListenerProcesses[$processId]);
-                        $this->_getProcessPool()->addChildProcess($newListenerProcess);
+                        try {
+                            $this->_getProcessPool()->addChildProcess($newListenerProcess);
+                            unset($this->_pausedListenerProcesses[$processId]);
+                        } catch (Exception $forkedException) {
+                            $this->_getLogger()->critical($forkedException->getMessage(), [(string)$forkedException]);
+                        }
                     }
-                }else {
+                } else {
                     break;
                 }
             }
-        }else {
+        } else {
             throw new \LogicException('There are no paused listener processes.');
         }
 

--- a/src/Process/Pool/Strategy/Server.php
+++ b/src/Process/Pool/Strategy/Server.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Neighborhoods\Kojo\Process\Pool\Strategy;
 
+use Neighborhoods\Kojo\Process\Forked\Exception;
 use Neighborhoods\Kojo\Process\Pool\StrategyAbstract;
 use Neighborhoods\Kojo\Process\Root;
 use Neighborhoods\Kojo\ProcessInterface;
@@ -17,7 +18,11 @@ class Server extends StrategyAbstract
         if ($process instanceof Root) {
             $this->_getProcessPool()->freeChildProcess($process->getProcessId());
             $rootProcess = $this->_getProcessCollection()->getProcessPrototypeClone($process->getTypeCode());
-            $this->_getProcessPool()->addChildProcess($rootProcess);
+            try {
+                $this->_getProcessPool()->addChildProcess($rootProcess);
+            } catch (Exception $forkedException) {
+                $this->_getLogger()->critical($forkedException->getMessage(), [(string)$forkedException]);
+            }
         } else {
             $className = get_class($process);
             throw new \UnexpectedValueException("Unexpected process class[$className].");
@@ -40,13 +45,22 @@ class Server extends StrategyAbstract
     {
         $this->_getProcessCollection()->applyProcessPool($this->_getProcessPool());
         foreach ($this->_getProcessCollection() as $process) {
-            $this->_getProcessPool()->addChildProcess($process);
+            try {
+                $this->_getProcessPool()->addChildProcess($process);
+            } catch (Exception $forkedException) {
+                $this->_getLogger()->critical($forkedException->getMessage(), [(string)$forkedException]);
+            }
         }
         if ($this->_hasFillProcessTypeCode() && $this->_getProcessPool()->canEnvironmentSustainAdditionProcesses()) {
             while (!$this->_getProcessPool()->isFull()) {
                 $fillProcessTypeCode = $this->_getFillProcessTypeCode();
                 $fillProcess = $this->_getProcessCollection()->getProcessPrototypeClone($fillProcessTypeCode);
-                $this->_getProcessPool()->addChildProcess($fillProcess);
+                try {
+                    $this->_getProcessPool()->addChildProcess($fillProcess);
+                } catch (Exception $forkedException) {
+                    $this->_getLogger()->critical($forkedException->getMessage(), [(string)$forkedException]);
+                    $this->_getProcessPool()->getProcess()->exit();
+                }
             }
         }
 

--- a/src/Process/PoolAbstract.php
+++ b/src/Process/PoolAbstract.php
@@ -32,9 +32,9 @@ abstract class PoolAbstract implements PoolInterface
     public function setAlarm(int $seconds): PoolInterface
     {
         if ($seconds === 0) {
-            $this->_getLogger()->info("Disabling any existing alarm.");
+            $this->_getLogger()->debug("Disabling any existing alarm.");
         }else {
-            $this->_getLogger()->info("Setting alarm for $seconds seconds.");
+            $this->_getLogger()->debug("Setting alarm for $seconds seconds.");
         }
         pcntl_alarm($seconds);
 

--- a/src/Process/Root.php
+++ b/src/Process/Root.php
@@ -17,7 +17,8 @@ class Root extends Forked implements ProcessInterface
     protected function _run(): Forked
     {
         while (true) {
-            $this->_getProcessSignal()->waitForSignal();
+            $this->_getProcessSignal()->processBufferedSignals();
+            sleep(1);
         }
 
         return $this;

--- a/src/Process/Signal.php
+++ b/src/Process/Signal.php
@@ -99,12 +99,18 @@ class Signal implements SignalInterface
             }
         } else {
             $information = $this->_getProcessSignalInformationFactory()->create()->hydrate($signalInformation);
-            if ($information->getSignalNumber() === SIGTERM) {
-                // Future Kōjō signal handlers MUST specify immediate or deferred processing.
-                // For now, SITGTERM is safe.
-                $this->processSignalInformation($information);
-            } else {
-                $this->bufferSignalInformation($information);
+            switch ($information->getSignalNumber()) {
+                case SIGTERM:
+                case SIGQUIT:
+                case SIGINT:
+                case SIGHUP:
+                    // Future Kōjō signal handlers MUST specify immediate or deferred processing.
+                    // For now, signals that imply termination are safe and necessary to process immediately.
+                    $this->processSignalInformation($information);
+                    break;
+                default:
+                    $this->bufferSignalInformation($information);
+                    break;
             }
         }
 

--- a/src/Process/Signal.php
+++ b/src/Process/Signal.php
@@ -122,14 +122,7 @@ class Signal implements SignalInterface
 
     public function setCanBufferSignals(bool $canBufferSignals): SignalInterface
     {
-        if ($this->canBufferSignals !== $canBufferSignals) {
-            $this->canBufferSignals = $canBufferSignals;
-        } else {
-            throw new \LogicException(sprintf(
-                'Can buffer signals is already set to [%s]',
-                $this->canBufferSignals ? 'true' : 'false'
-            ));
-        }
+        $this->canBufferSignals = $canBufferSignals;
 
         return $this;
     }

--- a/src/Process/Signal.php
+++ b/src/Process/Signal.php
@@ -13,113 +13,97 @@ class Signal implements SignalInterface
     use Defensive\AwareTrait;
     use Process\Signal\Information\Factory\AwareTrait;
     use Process\Pool\Logger\AwareTrait;
-    protected $_waitCount       = 0;
-    protected $_signalHandlers  = [];
-    protected $_bufferedSignals = [];
+    protected $signalHandlers = [];
+    protected $bufferedSignals = [];
 
     public function addSignalHandler(int $signalNumber, HandlerInterface $signalHandler): SignalInterface
     {
-        $this->incrementWaitCount();
         pcntl_async_signals(true);
-        $this->_signalHandlers[$signalNumber] = $signalHandler;
+        $this->signalHandlers[$signalNumber] = $signalHandler;
         pcntl_signal($signalNumber, [$this, 'handleSignal']);
-        $this->decrementWaitCount();
 
         return $this;
     }
 
-    public function incrementWaitCount(): SignalInterface
+    public function processBufferedSignals(): SignalInterface
     {
-        ++$this->_waitCount;
-
-        return $this;
-    }
-
-    public function decrementWaitCount(): SignalInterface
-    {
-        $this->block();
-        if ($this->_waitCount === 1) {
-            $this->_processBufferedSignals();
-        }
-        --$this->_waitCount;
-        $this->unBlock();
-
-        return $this;
-    }
-
-    protected function _processBufferedSignals(): SignalInterface
-    {
-        foreach ($this->_bufferedSignals as $position => $information) {
-            unset($this->_bufferedSignals[$position]);
-            call_user_func([$this->_getSignalHandler($information->getSignalNumber()), 'handleSignal'], $information);
+        foreach ($this->bufferedSignals as $position => $information) {
+            unset($this->bufferedSignals[$position]);
+            $this->processSignalInformation($information);
         }
 
         return $this;
     }
 
-    protected function _getSignalHandler(int $signalNumber): HandlerInterface
+    protected function processSignalInformation(InformationInterface $information): SignalInterface
     {
-        if (!isset($this->_signalHandlers[$signalNumber])) {
+        call_user_func([$this->getSignalHandler($information->getSignalNumber()), 'handleSignal'], $information);
+
+        return $this;
+    }
+
+    protected function getSignalHandler(int $signalNumber): HandlerInterface
+    {
+        if (!isset($this->signalHandlers[$signalNumber])) {
             throw new \LogicException("Signal handler for signal number[$signalNumber] is not set.");
         }
 
-        return $this->_signalHandlers[$signalNumber];
+        return $this->signalHandlers[$signalNumber];
     }
 
     /**
-     * Signals are "blocked" by PHP while the IRQ handling logic is executed
-     * from the context of being called by the VM as a signal handler.
+     * The VM uses sigprocmask and a global data structure to prevent reentrancy. The latter is not exposed to
+     * user space so all user space signal processing will be halted and until this method returns.
+     * This has a serious consequence when using fork, since the expectation is that the execution branch will not
+     * return. Since the kernel copies the exact memory image from the parent process to the new child process,
+     * the blocking VM data structure persists in the child process. Thereby blocking any future user space signal
+     * handling in the new process.
+     *
+     * Any non-terminating signals that result in non-deterministic or non-returning execution branches have to be
+     * buffered and processed using processBufferedSignals otherwise future signals will not be handled (since they
+     * will be blocked by the VM).
+     *
+     * Terminating signals however must be handled immediately.
+     *
+     * In the future, Kōjō signal handlers MUST specify whether or not they should be processed immediately, that is,
+     * with the knowledge that all other signals will be blocked until their execution branch returns, or if they
+     * should be buffered and deferred.
+     *
+     * Signals that specify that they should be handled immediately MUST return deterministically, or result
+     * in program termination.
      */
     public function handleSignal(int $signalNumber, $signalInformation): void
     {
+        $this->_getLogger()->debug(sprintf('Received signal[%s].', $signalNumber));
         if ($signalNumber === SIGCHLD) {
             while ($childProcessId = pcntl_wait($status, WNOHANG)) {
-                if ($childProcessId == -1) {
-                    $errorMessage = var_export(pcntl_strerror(pcntl_get_last_error()), true);
-                    $this->_getLogger()->notice("Received a process control wait error with message[$errorMessage].");
-                    break;
-                }else {
-                    $this->_getLogger()->info("Child with process ID[$childProcessId] exited with status[$status].");
+                $lastPCNTLError = pcntl_get_last_error();
+                if ($childProcessId != -1) {
+                    $this->_getLogger()->debug("Child with process ID[$childProcessId] exited with status[$status].");
                     $childInformation[InformationInterface::SIGNAL_NUMBER] = SIGCHLD;
                     $childInformation[InformationInterface::PROCESS_ID] = $childProcessId;
                     $childInformation[InformationInterface::EXIT_VALUE] = $status;
                     $information = $this->_getProcessSignalInformationFactory()->create()->hydrate($childInformation);
-                    $this->_bufferedSignals[] = $information;
+                    $this->bufferedSignals[] = $information;
+                } elseif ($lastPCNTLError === PCNTL_ECHILD) {
+                    break;
+                } else {
+                    $message = sprintf('Encountered pcntl error[%s] while processing SIGCHLD.', $lastPCNTLError);
+                    $this->_getLogger()->critical($message);
+                    throw new \RuntimeException($message);
                 }
             }
-        }else {
+        } else {
             $information = $this->_getProcessSignalInformationFactory()->create()->hydrate($signalInformation);
-            $this->_getLogger()->info("Handling signal number[{$information->getSignalNumber()}].");
-            $this->_bufferedSignals[] = $information;
-        }
-        if ($this->_waitCount === 0) {
-            $this->_processBufferedSignals();
+            if ($information->getSignalNumber() === SIGTERM) {
+                // Future Kōjō signal handlers MUST specify immediate or deferred processing.
+                // For now, SITGTERM is safe.
+                $this->processSignalInformation($information);
+            } else {
+                $this->bufferedSignals[] = $information;
+            }
         }
 
         return;
-    }
-
-    public function waitForSignal(): SignalInterface
-    {
-        $this->block();
-        $signalNumber = pcntl_sigwaitinfo(array_keys($this->_signalHandlers), $signalInformation);
-        $this->handleSignal($signalNumber, $signalInformation);
-        $this->unBlock();
-
-        return $this;
-    }
-
-    public function block(): SignalInterface
-    {
-        pcntl_sigprocmask(SIG_BLOCK, array_keys($this->_signalHandlers));
-
-        return $this;
-    }
-
-    public function unBlock(): SignalInterface
-    {
-        pcntl_sigprocmask(SIG_UNBLOCK, array_keys($this->_signalHandlers));
-
-        return $this;
     }
 }

--- a/src/Process/Signal.php
+++ b/src/Process/Signal.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Neighborhoods\Kojo\Process;
 
-use Neighborhoods\Kojo\Process\Signal\Exception;
 use Neighborhoods\Kojo\Process\Signal\HandlerInterface;
 use Neighborhoods\Kojo\Process\Signal\InformationInterface;
 use Neighborhoods\Pylon\Data\Property\Defensive;
@@ -33,13 +32,8 @@ class Signal implements SignalInterface
     public function processBufferedSignals(): SignalInterface
     {
         foreach ($this->bufferedSignals as $position => $information) {
-            try {
-                $this->processSignalInformation($information);
-                unset($this->bufferedSignals[$position]);
-            } catch (\Throwable $throwable) {
-                unset($this->bufferedSignals[$position]);
-                throw $throwable;
-            }
+            unset($this->bufferedSignals[$position]);
+            $this->processSignalInformation($information);
         }
 
         return $this;
@@ -131,7 +125,10 @@ class Signal implements SignalInterface
         if ($this->canBufferSignals !== $canBufferSignals) {
             $this->canBufferSignals = $canBufferSignals;
         } else {
-            throw new \LogicException(sprintf('Can buffer signals is already set to [%s]', $this->canBufferSignals));
+            throw new \LogicException(sprintf(
+                'Can buffer signals is already set to [%s]',
+                $this->canBufferSignals ? 'true' : 'false'
+            ));
         }
 
         return $this;

--- a/src/Process/SignalInterface.php
+++ b/src/Process/SignalInterface.php
@@ -7,20 +7,9 @@ use Neighborhoods\Kojo\Process\Signal\HandlerInterface;
 
 interface SignalInterface
 {
-    public function incrementWaitCount(): SignalInterface;
-
-    public function decrementWaitCount(): SignalInterface;
-
-    /**
-     * Signals are blocked by PHP while the IRQ handling logic is executed.
-     */
     public function handleSignal(int $signalNumber, $signalInformation): void;
 
     public function addSignalHandler(int $signalNumber, HandlerInterface $signalHandler): SignalInterface;
 
-    public function block(): SignalInterface;
-
-    public function waitForSignal(): SignalInterface;
-
-    public function unBlock(): SignalInterface;
+    public function processBufferedSignals(): SignalInterface;
 }

--- a/src/Process/SignalInterface.php
+++ b/src/Process/SignalInterface.php
@@ -12,4 +12,8 @@ interface SignalInterface
     public function addSignalHandler(int $signalNumber, HandlerInterface $signalHandler): SignalInterface;
 
     public function processBufferedSignals(): SignalInterface;
+
+    public function getCanBufferSignals(): bool;
+
+    public function setCanBufferSignals(bool $canBufferSignals): SignalInterface;
 }

--- a/src/ProcessAbstract.php
+++ b/src/ProcessAbstract.php
@@ -55,7 +55,7 @@ abstract class ProcessAbstract implements ProcessInterface
         $this->_getProcessSignal()->addSignalHandler(SIGQUIT, $this);
         $this->_getProcessSignal()->addSignalHandler(SIGABRT, $this);
         $this->_getProcessSignal()->addSignalHandler(SIGUSR1, $this);
-        $this->_getLogger()->debug('registered signal handlers.');
+        $this->_getLogger()->debug('Registered signal handlers.');
 
         return $this;
     }

--- a/src/ProcessAbstract.php
+++ b/src/ProcessAbstract.php
@@ -26,7 +26,6 @@ abstract class ProcessAbstract implements ProcessInterface
     {
         $this->_getApmNewRelic()->ignoreTransaction();
         $this->_getApmNewRelic()->endTransaction();
-        $this->_getProcessSignal()->incrementWaitCount();
         $this->_setParentProcessId(posix_getppid());
         $this->_setProcessId(posix_getpid());
 
@@ -42,7 +41,6 @@ abstract class ProcessAbstract implements ProcessInterface
         $this->_registerShutdownMethod();
         $this->_getProcessRegistry()->pushProcess($this);
         $this->_setProcessTitle();
-        $this->_getProcessSignal()->decrementWaitCount();
 
         return $this;
     }
@@ -57,6 +55,7 @@ abstract class ProcessAbstract implements ProcessInterface
         $this->_getProcessSignal()->addSignalHandler(SIGQUIT, $this);
         $this->_getProcessSignal()->addSignalHandler(SIGABRT, $this);
         $this->_getProcessSignal()->addSignalHandler(SIGUSR1, $this);
+        $this->_getLogger()->debug('registered signal handlers.');
 
         return $this;
     }
@@ -83,7 +82,6 @@ abstract class ProcessAbstract implements ProcessInterface
 
     public function handleSignal(InformationInterface $information): HandlerInterface
     {
-        $this->_getProcessSignal()->block();
         $this->exit();
 
         return $this;
@@ -98,7 +96,6 @@ abstract class ProcessAbstract implements ProcessInterface
 
     public function exit(): void
     {
-        $this->_getProcessSignal()->block();
         $this->unregisterShutdownMethod();
         $this->_getProcessPool()->terminateChildProcesses();
         exit($this->_exitCode);

--- a/src/Runtime/ExceptionInterface.php
+++ b/src/Runtime/ExceptionInterface.php
@@ -8,4 +8,6 @@ interface ExceptionInterface extends \Throwable, \JsonSerializable
     public function setCode(string $code): ExceptionInterface;
 
     public function addMessage(string $additionalMessage): ExceptionInterface;
+
+    public function jsonSerialize();
 }


### PR DESCRIPTION
* cleanup bin/kojo
* create and use an aggressive error handler for kojo space
* restore to VM error handler for user space
* update kojo container builder to comply with symfony deprecations
* make Mucha happy with newlines and some whitespace updates
* remove wait counting
* remove block and unblock
* update many log levels from info to debug
* remove pcntl_sigwaitinfo
* expose toggling signal buffering on and off
* catch and gracefully handle fork faults
* add a Forked Exception
* disable signal buffer for non-reactive processes
* catch a signal processor throwable