### PR TITLE
Fix reschedule crashed Jobs race condition

### DIFF
--- a/src/Maintainer.php
+++ b/src/Maintainer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Neighborhoods\Kojo;
 
 use Neighborhoods\Kojo\Data;
+use Neighborhoods\Kojo\Exception\Runtime\Db\Model\LoadException;
 use Neighborhoods\Kojo\Service\Update;
 use Neighborhoods\Kojo\Data\Job\Collection\CrashDetection;
 use Neighborhoods\Kojo\Data\Job\Collection\Schedule\LimitCheck;
@@ -73,7 +74,11 @@ class Maintainer implements MaintainerInterface
                 if ($jobSemaphoreResource->hasLock()) {
                     $jobSemaphoreResource->releaseLock();
                 }
-                throw $throwable;
+                if (!($throwable instanceof LoadException)
+                    || $throwable->getCode() !== LoadException::CODE_NO_DATA_LOADED
+                ) {
+                    throw $throwable;
+                }
             }
         }
 


### PR DESCRIPTION
A Job completes and is deleted after the Maintainer loads a collection
of potentially crashed Jobs but before reloading the Job in a protected
critical region.