### PR TITLE
KOJO-73 | Gracefully handle disabled statically scheduled job types

### DIFF
--- a/src/Scheduler.php
+++ b/src/Scheduler.php
@@ -50,7 +50,8 @@ class Scheduler implements SchedulerInterface
                     sprintf(
                         'Scheduler skipping disabled job type [%s]',
                         $jobType->getCode()
-                    )
+                    ),
+                    ['disabled_job_type_skipped' => $jobType->getCode()]
                 );
                 continue;
             }

--- a/src/Scheduler.php
+++ b/src/Scheduler.php
@@ -8,6 +8,7 @@ use Cron\CronExpression;
 use Neighborhoods\Pylon\Data\Property\Defensive;
 use Neighborhoods\Kojo\Data\Job;
 use Neighborhoods\Kojo\Api;
+use Neighborhoods\Kojo\Process\Pool\Logger;
 
 class Scheduler implements SchedulerInterface
 {
@@ -18,6 +19,7 @@ class Scheduler implements SchedulerInterface
     use Defensive\AwareTrait;
     use Service\Create\Factory\AwareTrait;
     use Semaphore\Resource\Factory\AwareTrait;
+    use Logger\AwareTrait;
 
     public function scheduleStaticJobs(): SchedulerInterface
     {
@@ -43,6 +45,15 @@ class Scheduler implements SchedulerInterface
         $schedulerCache = $this->_getSchedulerCache();
         $this->_getSchedulerJobCollection()->setReferenceDateTime($this->_getTime()->getNow());
         foreach ($this->_getSchedulerJobTypeCollection()->getIterator() as $jobType) {
+            if (!$jobType->getIsEnabled()) {
+                $this->_getLogger()->warning(
+                    sprintf(
+                        'Scheduler skipping disabled job type [%s]',
+                        $jobType->getCode()
+                    )
+                );
+                continue;
+            }
             $cronExpressionString = $jobType->getCronExpression();
             $typeCode = $jobType->getCode();
             $cronExpression = CronExpression::factory($cronExpressionString);

--- a/src/Scheduler.yml
+++ b/src/Scheduler.yml
@@ -10,6 +10,7 @@ services:
       - [setServiceCreateFactory, ['@service.create.factory']]
       - [addSemaphoreResourceFactory, ['@semaphore.resource.factory-schedule']]
       - [setSchedulerCache, ['@scheduler.cache']]
+      - [setLogger, ['@process.pool.logger']]
   scheduler:
     alias: neighborhoods.kojo.scheduler
     public: false


### PR DESCRIPTION
The fix is a lot simpler than I thought. I figured I would have to mess around with `Service\Create`, where the [actual exception was being thrown](https://github.com/neighborhoods/kojo/blob/4.x/src/Service/Create.php#L78), but I think kojo should still throw an exception if userspace tries to dynamically schedule a disabled job