### PR TITLE
KOJO-82 | Add error_get_last() to shutdown event

### DIFF
--- a/src/ProcessAbstract.php
+++ b/src/ProcessAbstract.php
@@ -109,7 +109,7 @@ abstract class ProcessAbstract implements ProcessInterface
             ini_set('memory_limit','-1');
             $this->_getLogger()->critical(
                 'Shutdown method invoked.',
-                ['error_get_last' => error_get_last()]
+                ['potentially_unrelated_error_get_last' => error_get_last()]
             );
             $this->_setOrReplaceExitCode(255);
             $this->exit();

--- a/src/ProcessAbstract.php
+++ b/src/ProcessAbstract.php
@@ -105,7 +105,12 @@ abstract class ProcessAbstract implements ProcessInterface
     public function shutdown(): ProcessInterface
     {
         if ($this->_read(self::PROP_IS_SHUTDOWN_METHOD_ACTIVE)) {
-            $this->_getLogger()->critical("Shutdown method invoked.");
+            // to avoid hitting artificial memory limits while executing this block
+            ini_set('memory_limit','-1');
+            $this->_getLogger()->critical(
+                'Shutdown method invoked.',
+                ['error_get_last' => error_get_last()]
+            );
             $this->_setOrReplaceExitCode(255);
             $this->exit();
         }


### PR DESCRIPTION
I added the `ini_set('memory_limit','-1');` because I kept getting OOM errors trying to log OOM errors in a test script, I don't think it'll cause any problems