### PR TITLE
KOJO-79 | Add robustness around redis command processing

### DIFF
--- a/src/Message/Broker/BrokerInterface.php
+++ b/src/Message/Broker/BrokerInterface.php
@@ -11,7 +11,7 @@ interface BrokerInterface
 
     public function hasMessage(): bool;
 
-    public function getNextMessage(): string;
+    public function attemptGetNextMessage(): ?string;
 
     public function getPublishChannelLength(): int;
 

--- a/src/Process/Listener/Command.php
+++ b/src/Process/Listener/Command.php
@@ -18,18 +18,21 @@ class Command extends ListenerAbstract implements CommandInterface
         return $this->_getMessageBroker()->hasMessage();
     }
 
-    public function processMessages(): ListenerInterface
+    public function processMessage(): ListenerInterface
     {
-        $message = $this->_getMessageBroker()->getNextMessage();
-        if (json_decode($message) !== null) {
-            $this->_getExpressionLanguage()->evaluate(
-                json_decode($message, true)['command'],
-                [
-                    'commandProcess' => $this,
-                ]
-            );
-        } else {
-            $this->_getLogger()->warning('The message is not a JSON: "' . $message . '".');
+        $message = $this->_getMessageBroker()->attemptGetNextMessage();
+
+        if ($message !== null) {
+            if (json_decode($message) !== null) {
+                $this->_getExpressionLanguage()->evaluate(
+                    json_decode($message, true)['command'],
+                    [
+                        'commandProcess' => $this,
+                    ]
+                );
+            } else {
+                $this->_getLogger()->warning('The message is not a JSON: "' . $message . '".');
+            }
         }
 
         return $this;

--- a/src/Process/Listener/Mutex/Redis.php
+++ b/src/Process/Listener/Mutex/Redis.php
@@ -42,7 +42,7 @@ class Redis extends ListenerAbstract implements RedisInterface
         return $this;
     }
 
-    public function processMessages(): ListenerInterface
+    public function processMessage(): ListenerInterface
     {
         throw new \RuntimeException('The connection to redis was lost.');
     }

--- a/src/Process/ListenerInterface.php
+++ b/src/Process/ListenerInterface.php
@@ -7,7 +7,7 @@ use Neighborhoods\Kojo\ProcessInterface;
 
 interface ListenerInterface extends ProcessInterface
 {
-    public function processMessages(): ListenerInterface;
+    public function processMessage(): ListenerInterface;
 
     public function hasMessages(): bool;
 }

--- a/src/Process/Pool/Strategy.php
+++ b/src/Process/Pool/Strategy.php
@@ -33,11 +33,11 @@ class Strategy extends StrategyAbstract
             $this->_pauseListenerProcess($listenerProcess);
         } else {
             while (
-                $listenerProcess->hasMessages()
-                && !$this->_getProcessPool()->isFull()
+                !$this->_getProcessPool()->isFull()
                 && $this->_getProcessPool()->canEnvironmentSustainAdditionProcesses()
+                && $listenerProcess->hasMessages()
             ) {
-                $listenerProcess->processMessages();
+                $listenerProcess->processMessage();
             }
 
             if ($this->_getProcessPool()->isFull()) {
@@ -171,8 +171,12 @@ class Strategy extends StrategyAbstract
                 if (!$this->_getProcessPool()->isFull()) {
                     $typeCode = $listenerProcess->getTypeCode();
                     $newListenerProcess = $this->_getProcessCollection()->getProcessPrototypeClone($typeCode);
-                    while (!$this->_getProcessPool()->isFull() && $listenerProcess->hasMessages()) {
-                        $listenerProcess->processMessages();
+                    while (
+                        !$this->_getProcessPool()->isFull() &&
+                        $this->_getProcessPool()->canEnvironmentSustainAdditionProcesses() &&
+                        $listenerProcess->hasMessages()
+                    ) {
+                        $listenerProcess->processMessage();
                     }
                     if (!$this->_getProcessPool()->isFull()) {
                         try {

--- a/src/Process/Pool/Strategy/Worker.php
+++ b/src/Process/Pool/Strategy/Worker.php
@@ -28,9 +28,8 @@ class Worker extends StrategyAbstract
     protected function _listenerProcessExited(ListenerInterface $listenerProcess): StrategyInterface
     {
         while ($listenerProcess->hasMessages()) {
-            $listenerProcess->processMessages();
+            $listenerProcess->processMessage();
         }
-
 
         return $this;
     }


### PR DESCRIPTION
Main change is `Message\Broker\BrokerInterface`'s `getNextMessage() : string` -> `attemptGetNextMessage() : ?string` and making `Process\Listener\Command` robust to the absence of messages

Ideally I would have liked something like `getMessages() : \Generator` to replace `hasMessage()` followed by `getNextMessage()`, which would remove the need for checking the list length, and rely solely on the existence of a message. However, that didn't work as an indicator for the `Process\Listener\Command` to block until messages are available. It would also wouldn't work in cases where we conditionally process the message (e.g. if the process pool isn't full), because the message is already pulled from redis