### PR TITLE
KOJO-86 | Remove some shallow cloning from job type registrar

### DIFF
--- a/src/Api/V1/Job/Type/Registrar.php
+++ b/src/Api/V1/Job/Type/Registrar.php
@@ -11,94 +11,105 @@ class Registrar implements RegistrarInterface
     use Property\Defensive\AwareTrait;
     use Type\Service\Create\AwareTrait;
 
+    /** @var Type\Service\CreateInterface */
+    protected $typeServiceCreate;
+
     public function save(): RegistrarInterface
     {
-        $this->_getTypeServiceCreate()->save();
+        $this->getTypeServiceCreate()->save();
 
         return $this;
     }
 
     public function setCode(string $code): RegistrarInterface
     {
-        $this->_getTypeServiceCreate()->setCode($code);
+        $this->getTypeServiceCreate()->setCode($code);
 
         return $this;
     }
 
     public function setWorkerClassUri(string $workerModelUri): RegistrarInterface
     {
-        $this->_getTypeServiceCreate()->setWorkerClassUri($workerModelUri);
+        $this->getTypeServiceCreate()->setWorkerClassUri($workerModelUri);
 
         return $this;
     }
 
     public function setWorkerMethod(string $workerMethod): RegistrarInterface
     {
-        $this->_getTypeServiceCreate()->setWorkerMethod($workerMethod);
+        $this->getTypeServiceCreate()->setWorkerMethod($workerMethod);
 
         return $this;
     }
 
     public function setName(string $name): RegistrarInterface
     {
-        $this->_getTypeServiceCreate()->setName($name);
+        $this->getTypeServiceCreate()->setName($name);
 
         return $this;
     }
 
     public function setCronExpression(string $cronExpression): RegistrarInterface
     {
-        $this->_getTypeServiceCreate()->setCronExpression($cronExpression);
+        $this->getTypeServiceCreate()->setCronExpression($cronExpression);
 
         return $this;
     }
 
     public function setCanWorkInParallel(bool $canWorkInParallel): RegistrarInterface
     {
-        $this->_getTypeServiceCreate()->setCanWorkInParallel($canWorkInParallel);
+        $this->getTypeServiceCreate()->setCanWorkInParallel($canWorkInParallel);
 
         return $this;
     }
 
     public function setDefaultImportance(int $defaultImportance): RegistrarInterface
     {
-        $this->_getTypeServiceCreate()->setDefaultImportance($defaultImportance);
+        $this->getTypeServiceCreate()->setDefaultImportance($defaultImportance);
 
         return $this;
     }
 
     public function setScheduleLimit(int $scheduleLimit): RegistrarInterface
     {
-        $this->_getTypeServiceCreate()->setScheduleLimit($scheduleLimit);
+        $this->getTypeServiceCreate()->setScheduleLimit($scheduleLimit);
 
         return $this;
     }
 
     public function setScheduleLimitAllowance(int $scheduleLimitAllowance): RegistrarInterface
     {
-        $this->_getTypeServiceCreate()->setScheduleLimitAllowance($scheduleLimitAllowance);
+        $this->getTypeServiceCreate()->setScheduleLimitAllowance($scheduleLimitAllowance);
 
         return $this;
     }
 
     public function setIsEnabled(bool $isEnabled): RegistrarInterface
     {
-        $this->_getTypeServiceCreate()->setIsEnabled($isEnabled);
+        $this->getTypeServiceCreate()->setIsEnabled($isEnabled);
 
         return $this;
     }
 
     public function setAutoCompleteSuccess(bool $autoCompleteSuccess): RegistrarInterface
     {
-        $this->_getTypeServiceCreate()->setAutoCompleteSuccess($autoCompleteSuccess);
+        $this->getTypeServiceCreate()->setAutoCompleteSuccess($autoCompleteSuccess);
 
         return $this;
     }
 
     public function setAutoDeleteIntervalDuration(string $autoDeleteIntervalDuration): RegistrarInterface
     {
-        $this->_getTypeServiceCreate()->setAutoDeleteIntervalDuration($autoDeleteIntervalDuration);
+        $this->getTypeServiceCreate()->setAutoDeleteIntervalDuration($autoDeleteIntervalDuration);
 
         return $this;
+    }
+
+    protected function getTypeServiceCreate() : Type\Service\CreateInterface
+    {
+        if ($this->typeServiceCreate === null) {
+            $this->typeServiceCreate = $this->_getTypeServiceCreateClone();
+        }
+        return $this->typeServiceCreate;
     }
 }

--- a/src/Type/Service/Create.php
+++ b/src/Type/Service/Create.php
@@ -4,97 +4,109 @@ declare(strict_types=1);
 namespace Neighborhoods\Kojo\Type\Service;
 
 use Neighborhoods\Kojo\Type;
+use Neighborhoods\Kojo\Data\Job;
 
 class Create extends Type\ServiceAbstract implements CreateInterface
 {
+    /** @var Job\TypeInterface */
+    protected $jobType;
+
     public function _save(): CreateInterface
     {
-        $this->_getJobType()->save();
+        $this->getJobType()->save();
 
         return $this;
     }
 
     public function setCode(string $code): CreateInterface
     {
-        $this->_getJobType()->setCode($code);
+        $this->getJobType()->setCode($code);
 
         return $this;
     }
 
     public function setWorkerClassUri(string $workerModelUri): CreateInterface
     {
-        $this->_getJobType()->setWorkerClassUri($workerModelUri);
+        $this->getJobType()->setWorkerClassUri($workerModelUri);
 
         return $this;
     }
 
     public function setWorkerMethod(string $workerMethod): CreateInterface
     {
-        $this->_getJobType()->setWorkerMethod($workerMethod);
+        $this->getJobType()->setWorkerMethod($workerMethod);
 
         return $this;
     }
 
     public function setName(string $name): CreateInterface
     {
-        $this->_getJobType()->setName($name);
+        $this->getJobType()->setName($name);
 
         return $this;
     }
 
     public function setCronExpression(string $cronExpression): CreateInterface
     {
-        $this->_getJobType()->setCronExpression($cronExpression);
+        $this->getJobType()->setCronExpression($cronExpression);
 
         return $this;
     }
 
     public function setCanWorkInParallel(bool $canWorkInParallel): CreateInterface
     {
-        $this->_getJobType()->setCanWorkInParallel($canWorkInParallel);
+        $this->getJobType()->setCanWorkInParallel($canWorkInParallel);
 
         return $this;
     }
 
     public function setDefaultImportance(int $defaultImportance): CreateInterface
     {
-        $this->_getJobType()->setDefaultImportance($defaultImportance);
+        $this->getJobType()->setDefaultImportance($defaultImportance);
 
         return $this;
     }
 
     public function setScheduleLimit(int $scheduleLimit): CreateInterface
     {
-        $this->_getJobType()->setScheduleLimit($scheduleLimit);
+        $this->getJobType()->setScheduleLimit($scheduleLimit);
 
         return $this;
     }
 
     public function setScheduleLimitAllowance(int $scheduleLimitAllowance): CreateInterface
     {
-        $this->_getJobType()->setScheduleLimitAllowance($scheduleLimitAllowance);
+        $this->getJobType()->setScheduleLimitAllowance($scheduleLimitAllowance);
 
         return $this;
     }
 
     public function setIsEnabled(bool $isEnabled): CreateInterface
     {
-        $this->_getJobType()->setIsEnabled($isEnabled);
+        $this->getJobType()->setIsEnabled($isEnabled);
 
         return $this;
     }
 
     public function setAutoCompleteSuccess(bool $autoCompleteSuccess): CreateInterface
     {
-        $this->_getJobType()->setAutoCompleteSuccess($autoCompleteSuccess);
+        $this->getJobType()->setAutoCompleteSuccess($autoCompleteSuccess);
 
         return $this;
     }
 
     public function setAutoDeleteIntervalDuration(string $autoDeleteIntervalDuration): CreateInterface
     {
-        $this->_getJobType()->setAutoDeleteIntervalDuration($autoDeleteIntervalDuration);
+        $this->getJobType()->setAutoDeleteIntervalDuration($autoDeleteIntervalDuration);
 
         return $this;
+    }
+
+    protected function getJobType() : Job\TypeInterface
+    {
+        if ($this->jobType === null) {
+            $this->jobType = $this->_getJobTypeClone();
+        }
+        return $this->jobType;
     }
 }

--- a/src/Type/Service/Create/AwareTrait.php
+++ b/src/Type/Service/Create/AwareTrait.php
@@ -21,7 +21,7 @@ trait AwareTrait
 
     protected function _getTypeServiceCreateClone(): CreateInterface
     {
-        return clone $this->_getServiceCreate();
+        return clone $this->_getTypeServiceCreate();
     }
 
     protected function _unsetTypeServiceCreate()


### PR DESCRIPTION
Before:
```
$firstJobTypeService = (new Kojo\Api\V1\Job\Type\Service())->addYmlServiceFinder($finder);
$firstJobTypeRegistrar = $firstJobTypeService->getNewJobTypeRegistrar();
// register first job

$secondJobTypeService = (new Kojo\Api\V1\Job\Type\Service())->addYmlServiceFinder($finder);
$secondJobTypeRegistrar = $secondJobTypeService->getNewJobTypeRegistrar();
// register second job

...
```

After:
```
$jobTypeService = (new Kojo\Api\V1\Job\Type\Service())->addYmlServiceFinder($finder);

$firstJobTypeRegistrar = $jobTypeService->getNewJobTypeRegistrar();
// register first job

$secondJobTypeRegistrar = $jobTypeService->getNewJobTypeRegistrar();
// register second job

...
```

Since kojo doesn't cache its DI container in the filesystem, re-creating it for every job type was expensive (especially in docker for mac), now we can re-use that runtime for registering additional jobs

The problem was the shallow cloning of the `Registrar`, which was shallowly cloning its `Type\Service\Create`, so some state (namely the `Job\Type` model) was persisting across "new" registrars, combined with the explodiness that prevented us from re-setting properties (e.g. `type_code`) on the inadvertently shared `Job\Type` model