### PR TITLE
Pass exceptions as an object under the 'exception' key, and normalize that key if it's a throwable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
         "symfony/finder": "^4.0",
         "zendframework/zend-db": "^2.8",
         "dragonmantank/cron-expression": "^2.0",
-        "doctrine/dbal": "^2.7"
+        "doctrine/dbal": "^2.7",
+        "monolog/monolog": "^1.24.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0",

--- a/src/Message/Broker/Redis.php
+++ b/src/Message/Broker/Redis.php
@@ -21,7 +21,7 @@ class Redis extends BrokerAbstract
                 0
             );
         } catch (\Throwable $throwable) {
-            $this->_getLogger()->critical($throwable->getMessage(), [(string)$throwable]);
+            $this->_getLogger()->critical($throwable->getMessage(), ['exception' => $throwable]);
             throw $throwable;
         }
 
@@ -43,7 +43,7 @@ class Redis extends BrokerAbstract
             $publishChannelLength = $this->getPublishChannelLength();
             $subscriptionChannelLength = $this->getSubscriptionChannelLength();
         } catch (\Throwable $throwable) {
-            $this->_getLogger()->critical($throwable->getMessage(), [(string)$throwable]);
+            $this->_getLogger()->critical($throwable->getMessage(), ['exception' => $throwable]);
             throw $throwable;
         }
 
@@ -58,7 +58,7 @@ class Redis extends BrokerAbstract
                 $message = $this->_getRedisClient()->rPop($this->_getPublishChannelName());
             }
         } catch (\Throwable $throwable) {
-            $this->_getLogger()->critical($throwable->getMessage(), [(string)$throwable]);
+            $this->_getLogger()->critical($throwable->getMessage(), ['exception' => $throwable]);
             throw $throwable;
         }
 
@@ -70,7 +70,7 @@ class Redis extends BrokerAbstract
         try {
             $publishChannelLength = $this->_getRedisClient()->lLen($this->_getPublishChannelName());
         } catch (\Throwable $throwable) {
-            $this->_getLogger()->critical($throwable->getMessage(), [(string)$throwable]);
+            $this->_getLogger()->critical($throwable->getMessage(), ['exception' => $throwable]);
             throw $throwable;
         }
 
@@ -82,7 +82,7 @@ class Redis extends BrokerAbstract
         try {
             $subscriptionChannelLength = $this->_getRedisClient()->lLen($this->_getSubscriptionChannelName());
         } catch (\Throwable $throwable) {
-            $this->_getLogger()->critical($throwable->getMessage(), [(string)$throwable]);
+            $this->_getLogger()->critical($throwable->getMessage(), ['exception' => $throwable]);
             throw $throwable;
         }
 
@@ -94,7 +94,7 @@ class Redis extends BrokerAbstract
         try {
             $this->_getRedisClient()->lPush($this->_getPublishChannelName(), $message);
         } catch (\Throwable $throwable) {
-            $this->_getLogger()->critical($throwable->getMessage(), [(string)$throwable]);
+            $this->_getLogger()->critical($throwable->getMessage(), ['exception' => $throwable]);
             throw $throwable;
         }
 

--- a/src/Process/Job.php
+++ b/src/Process/Job.php
@@ -28,7 +28,7 @@ class Job extends Forked implements JobInterface
             $this->_getMaintainer()->deleteCompletedJobs();
             $this->_getForeman()->workWorker();
         } catch (\Throwable $throwable) {
-            $this->_getLogger()->critical($throwable->getMessage(), [(string)$throwable]);
+            $this->_getLogger()->critical($throwable->getMessage(), ['exception' => $throwable]);
             $this->_setOrReplaceExitCode(255);
         }
 

--- a/src/Process/Listener/Command.php
+++ b/src/Process/Listener/Command.php
@@ -41,7 +41,7 @@ class Command extends ListenerAbstract implements CommandInterface
         try {
             $this->_getProcessPool()->addChildProcess($process);
         } catch (Exception $forkedException) {
-            $this->_getLogger()->critical($forkedException->getMessage(), [(string)$forkedException]);
+            $this->_getLogger()->critical($forkedException->getMessage(), ['exception' => $forkedException]);
         }
 
         return $this;

--- a/src/Process/Pool/Logger.php
+++ b/src/Process/Pool/Logger.php
@@ -54,11 +54,9 @@ class Logger extends Log\AbstractLogger implements LoggerInterface
 
                 if (array_key_exists(self::CONTEXT_KEY_EXCEPTION, $context) && $context[self::CONTEXT_KEY_EXCEPTION]
                 instanceof \Throwable){
-                    $exceptionObject = $context[self::CONTEXT_KEY_EXCEPTION];
                     $normalizedException = (new NormalizerFormatter())->format([$context[self::CONTEXT_KEY_EXCEPTION]]);
                     unset($context[self::CONTEXT_KEY_EXCEPTION]);
-                    $formattedException = ['exception_string'=> (string)$exceptionObject];
-                    $context['exception'] = $normalizedException;
+                    $context['exception'] = $normalizedException[0];
                 }
 
                 if (json_encode($context) === false) {

--- a/src/Process/Pool/Logger.php
+++ b/src/Process/Pool/Logger.php
@@ -16,6 +16,7 @@ class Logger extends Log\AbstractLogger implements LoggerInterface
     use Defensive\AwareTrait;
     public const PROP_IS_ENABLED = 'is_enabled';
     protected const LOG_DATE_TIME_FORMAT = 'D, d M y H:i:s.u T';
+    const CONTEXT_KEY_EXCEPTION = 'exception';
 
     protected $log_formatter;
     protected $level_filter_mask;
@@ -49,6 +50,15 @@ class Logger extends Log\AbstractLogger implements LoggerInterface
                 $logMessage->setProcessId($processId);
                 $logMessage->setProcessPath($this->_getProcess()->getPath());
                 $logMessage->setMessage($message);
+
+                if (array_key_exists(self::CONTEXT_KEY_EXCEPTION, $context) && $context[self::CONTEXT_KEY_EXCEPTION]
+                instanceof \Throwable){
+                    $exceptionObject = $context[self::CONTEXT_KEY_EXCEPTION];
+                    unset($context[self::CONTEXT_KEY_EXCEPTION]);
+                    $formattedException = ['exception_string'=> (string)$exceptionObject];
+                    $context['exception'] = $formattedException;
+                }
+
                 if (json_encode($context) === false) {
                     $logMessage->setContext([]);
                 } else {

--- a/src/Process/Pool/Logger.php
+++ b/src/Process/Pool/Logger.php
@@ -54,6 +54,7 @@ class Logger extends Log\AbstractLogger implements LoggerInterface
 
                 if (array_key_exists(self::CONTEXT_KEY_EXCEPTION, $context) && $context[self::CONTEXT_KEY_EXCEPTION]
                 instanceof \Throwable){
+                    $context['exception_sting'] = (string)$context[self::CONTEXT_KEY_EXCEPTION];
                     $normalizedException = (new NormalizerFormatter())->format([$context[self::CONTEXT_KEY_EXCEPTION]]);
                     unset($context[self::CONTEXT_KEY_EXCEPTION]);
                     $context['exception'] = $normalizedException[0];

--- a/src/Process/Pool/Logger.php
+++ b/src/Process/Pool/Logger.php
@@ -15,9 +15,12 @@ class Logger extends Log\AbstractLogger implements LoggerInterface
     use Time\AwareTrait;
     use Logger\Message\Factory\AwareTrait;
     use Defensive\AwareTrait;
+
     public const PROP_IS_ENABLED = 'is_enabled';
+    public const CONTEXT_KEY_EXCEPTION = 'exception';
+    public const CONTEXT_KEY_EXCEPTION_STRING = 'exception_string';
+
     protected const LOG_DATE_TIME_FORMAT = 'D, d M y H:i:s.u T';
-    const CONTEXT_KEY_EXCEPTION = 'exception';
 
     protected $log_formatter;
     protected $level_filter_mask;
@@ -54,10 +57,10 @@ class Logger extends Log\AbstractLogger implements LoggerInterface
 
                 if (array_key_exists(self::CONTEXT_KEY_EXCEPTION, $context) && $context[self::CONTEXT_KEY_EXCEPTION]
                 instanceof \Throwable){
-                    $context['exception_sting'] = (string)$context[self::CONTEXT_KEY_EXCEPTION];
+                    $context[self::CONTEXT_KEY_EXCEPTION_STRING] = (string)$context[self::CONTEXT_KEY_EXCEPTION];
                     $normalizedException = (new NormalizerFormatter())->format([$context[self::CONTEXT_KEY_EXCEPTION]]);
                     unset($context[self::CONTEXT_KEY_EXCEPTION]);
-                    $context['exception'] = $normalizedException[0];
+                    $context[self::CONTEXT_KEY_EXCEPTION] = $normalizedException[0];
                 }
 
                 if (json_encode($context) === false) {

--- a/src/Process/Pool/Logger.php
+++ b/src/Process/Pool/Logger.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Neighborhoods\Kojo\Process\Pool;
 
+use Monolog\Formatter\NormalizerFormatter;
 use Neighborhoods\Kojo\Process\Pool\Logger\FormatterInterface;
 use Neighborhoods\Kojo\ProcessInterface;
 use Neighborhoods\Pylon\Data\Property\Defensive;
@@ -54,9 +55,10 @@ class Logger extends Log\AbstractLogger implements LoggerInterface
                 if (array_key_exists(self::CONTEXT_KEY_EXCEPTION, $context) && $context[self::CONTEXT_KEY_EXCEPTION]
                 instanceof \Throwable){
                     $exceptionObject = $context[self::CONTEXT_KEY_EXCEPTION];
+                    $normalizedException = (new NormalizerFormatter())->format([$context[self::CONTEXT_KEY_EXCEPTION]]);
                     unset($context[self::CONTEXT_KEY_EXCEPTION]);
                     $formattedException = ['exception_string'=> (string)$exceptionObject];
-                    $context['exception'] = $formattedException;
+                    $context['exception'] = $normalizedException;
                 }
 
                 if (json_encode($context) === false) {

--- a/src/Process/Pool/Strategy.php
+++ b/src/Process/Pool/Strategy.php
@@ -50,7 +50,7 @@ class Strategy extends StrategyAbstract
                     $this->_getProcessPool()->addChildProcess($replacementListenerProcess);
                 } catch (Exception $forkedException) {
                     $this->_pauseListenerProcess($listenerProcess);
-                    $this->_getLogger()->critical($forkedException->getMessage(), [(string)$forkedException]);
+                    $this->_getLogger()->critical($forkedException->getMessage(), ['exception' => $forkedException]);
                 }
             }
         }
@@ -85,7 +85,7 @@ class Strategy extends StrategyAbstract
             try {
                 $this->_getProcessPool()->addChildProcess($replacementProcess);
             } catch (Exception $forkedException) {
-                $this->_getLogger()->critical($forkedException->getMessage(), [(string)$forkedException]);
+                $this->_getLogger()->critical($forkedException->getMessage(), ['exception' => $forkedException]);
             }
             if (!$this->_getProcessPool()->hasAlarm()) {
                 $this->_getProcessPool()->setAlarm($this->getMaxAlarmTime());
@@ -106,7 +106,7 @@ class Strategy extends StrategyAbstract
                 try {
                     $this->_getProcessPool()->addChildProcess($alarmProcess);
                 } catch (Exception $forkedException) {
-                    $this->_getLogger()->critical($forkedException->getMessage(), [(string)$forkedException]);
+                    $this->_getLogger()->critical($forkedException->getMessage(), ['exception' => $forkedException]);
                 }
             }
         }
@@ -125,7 +125,7 @@ class Strategy extends StrategyAbstract
             try {
                 $this->_getProcessPool()->addChildProcess($process);
             } catch (Exception $forkedException) {
-                $this->_getLogger()->critical($forkedException->getMessage(), [(string)$forkedException]);
+                $this->_getLogger()->critical($forkedException->getMessage(), ['exception' => $forkedException]);
                 if ($process instanceof CommandInterface) {
                     $this->_getProcessPool()->getProcess()->exit();
                 }
@@ -138,7 +138,7 @@ class Strategy extends StrategyAbstract
                 try {
                     $this->_getProcessPool()->addChildProcess($fillProcess);
                 } catch (Exception $forkedException) {
-                    $this->_getLogger()->critical($forkedException->getMessage(), [(string)$forkedException]);
+                    $this->_getLogger()->critical($forkedException->getMessage(), ['exception' => $forkedException]);
                 }
             }
         }
@@ -179,7 +179,7 @@ class Strategy extends StrategyAbstract
                             $this->_getProcessPool()->addChildProcess($newListenerProcess);
                             unset($this->_pausedListenerProcesses[$processId]);
                         } catch (Exception $forkedException) {
-                            $this->_getLogger()->critical($forkedException->getMessage(), [(string)$forkedException]);
+                            $this->_getLogger()->critical($forkedException->getMessage(), ['exception' => $forkedException]);
                         }
                     }
                 } else {

--- a/src/Process/Pool/Strategy/Server.php
+++ b/src/Process/Pool/Strategy/Server.php
@@ -21,7 +21,7 @@ class Server extends StrategyAbstract
             try {
                 $this->_getProcessPool()->addChildProcess($rootProcess);
             } catch (Exception $forkedException) {
-                $this->_getLogger()->critical($forkedException->getMessage(), [(string)$forkedException]);
+                $this->_getLogger()->critical($forkedException->getMessage(), ['exception' => $forkedException]);
             }
         } else {
             $className = get_class($process);
@@ -48,7 +48,7 @@ class Server extends StrategyAbstract
             try {
                 $this->_getProcessPool()->addChildProcess($process);
             } catch (Exception $forkedException) {
-                $this->_getLogger()->critical($forkedException->getMessage(), [(string)$forkedException]);
+                $this->_getLogger()->critical($forkedException->getMessage(), ['exception' => $forkedException]);
                 $this->_getProcessPool()->getProcess()->exit();
             }
         }
@@ -59,7 +59,7 @@ class Server extends StrategyAbstract
                 try {
                     $this->_getProcessPool()->addChildProcess($fillProcess);
                 } catch (Exception $forkedException) {
-                    $this->_getLogger()->critical($forkedException->getMessage(), [(string)$forkedException]);
+                    $this->_getLogger()->critical($forkedException->getMessage(), ['exception' => $forkedException]);
                     $this->_getProcessPool()->getProcess()->exit();
                 }
             }

--- a/src/Process/Pool/Strategy/Worker.php
+++ b/src/Process/Pool/Strategy/Worker.php
@@ -52,7 +52,7 @@ class Worker extends StrategyAbstract
             try {
                 $this->_getProcessPool()->addChildProcess($process);
             } catch (Exception $forkedException) {
-                $this->_getLogger()->critical($forkedException->getMessage(), [(string)$forkedException]);
+                $this->_getLogger()->critical($forkedException->getMessage(), ['exception' => $forkedException]);
                 $this->_getProcessPool()->getProcess()->exit();
             }
         }
@@ -63,7 +63,7 @@ class Worker extends StrategyAbstract
                 try {
                     $this->_getProcessPool()->addChildProcess($fillProcess);
                 } catch (Exception $forkedException) {
-                    $this->_getLogger()->critical($forkedException->getMessage(), [(string)$forkedException]);
+                    $this->_getLogger()->critical($forkedException->getMessage(), ['exception' => $forkedException]);
                     $this->_getProcessPool()->getProcess()->exit();
                 }
             }


### PR DESCRIPTION
Normalize the exception to be both string and object based:

```json
{
  "time": "Mon, 01 Apr 19 02:10:05.589843 UTC",
  "level": "critical",
  "process_id": "912",
  "process_path": "/server[867]/root[871]/job[912]",
  "message": "Panicking job with ID[13362].",
  "context": {
    "exception_sting": "TypeError: Argument 1 passed to Neighborhoods\\KojoFitnessUseCase46\\V1\\Worker\\Delegate::onlyTakesIntegers() must be of the type integer, string given, called in /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/src/V1/Worker/Delegate.php on line 33 and defined in /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/src/V1/Worker/Delegate.php:45\nStack trace:\n#0 /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/src/V1/Worker/Delegate.php(33): Neighborhoods\\KojoFitnessUseCase46\\V1\\Worker\\Delegate->onlyTakesIntegers('Not very lucky')\n#1 /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/src/V1/Worker.php(55): Neighborhoods\\KojoFitnessUseCase46\\V1\\Worker\\Delegate->businessLogic()\n#2 /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/src/V1/Worker.php(25): Neighborhoods\\KojoFitnessUseCase46\\V1\\Worker->_delegateWork()\n#3 /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/src/V1/Worker/Facade.php(21): Neighborhoods\\KojoFitnessUseCase46\\V1\\Worker->work()\n#4 [internal function]: Neighborhoods\\KojoFitnessUseCase46\\V1\\Worker\\Facade->start()\n#5 /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Foreman.php(89): call_user_func(Array)\n#6 /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Foreman.php(47): Neighborhoods\\Kojo\\Foreman->_runWorker()\n#7 /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Foreman.php(35): Neighborhoods\\Kojo\\Foreman->_workWorker()\n#8 /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Job.php(29): Neighborhoods\\Kojo\\Foreman->workWorker()\n#9 /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Forked.php(32): Neighborhoods\\Kojo\\Process\\Job->_run()\n#10 /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Pool.php(85): Neighborhoods\\Kojo\\Process\\Forked->start()\n#11 /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Pool/Strategy.php(86): Neighborhoods\\Kojo\\Process\\Pool->addChildProcess(Object(Neighborhoods\\Kojo\\Process\\Job))\n#12 /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Pool/Strategy.php(19): Neighborhoods\\Kojo\\Process\\Pool\\Strategy->_jobProcessExited(Object(Neighborhoods\\Kojo\\Process\\Job))\n#13 /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Pool.php(46): Neighborhoods\\Kojo\\Process\\Pool\\Strategy->childProcessExited(Object(Neighborhoods\\Kojo\\Process\\Job))\n#14 /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Pool.php(28): Neighborhoods\\Kojo\\Process\\Pool->_childExitSignal(Object(Neighborhoods\\Kojo\\Process\\Signal\\Information))\n#15 [internal function]: Neighborhoods\\Kojo\\Process\\Pool->handleSignal(Object(Neighborhoods\\Kojo\\Process\\Signal\\Information))\n#16 /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Signal.php(44): call_user_func(Array, Object(Neighborhoods\\Kojo\\Process\\Signal\\Information))\n#17 /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Signal.php(36): Neighborhoods\\Kojo\\Process\\Signal->processSignalInformation(Object(Neighborhoods\\Kojo\\Process\\Signal\\Information))\n#18 /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Root.php(20): Neighborhoods\\Kojo\\Process\\Signal->processBufferedSignals()\n#19 /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Forked.php(32): Neighborhoods\\Kojo\\Process\\Root->_run()\n#20 /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Pool.php(85): Neighborhoods\\Kojo\\Process\\Forked->start()\n#21 /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Pool/Strategy/Server.php(49): Neighborhoods\\Kojo\\Process\\Pool->addChildProcess(Object(Neighborhoods\\Kojo\\Process\\Root))\n#22 /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/PoolAbstract.php(61): Neighborhoods\\Kojo\\Process\\Pool\\Strategy\\Server->initializePool()\n#23 /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Pool.php(18): Neighborhoods\\Kojo\\Process\\PoolAbstract->_initialize()\n#24 /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Pool/Server.php(27): Neighborhoods\\Kojo\\Process\\Pool->start()\n#25 /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/bin/kojo(36): Neighborhoods\\Kojo\\Process\\Pool\\Server->start()\n#26 {main}\n\nNext RuntimeException: Panicking job with ID[13362]. in /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Foreman.php:52\nStack trace:\n#0 /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Foreman.php(35): Neighborhoods\\Kojo\\Foreman->_workWorker()\n#1 /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Job.php(29): Neighborhoods\\Kojo\\Foreman->workWorker()\n#2 /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Forked.php(32): Neighborhoods\\Kojo\\Process\\Job->_run()\n#3 /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Pool.php(85): Neighborhoods\\Kojo\\Process\\Forked->start()\n#4 /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Pool/Strategy.php(86): Neighborhoods\\Kojo\\Process\\Pool->addChildProcess(Object(Neighborhoods\\Kojo\\Process\\Job))\n#5 /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Pool/Strategy.php(19): Neighborhoods\\Kojo\\Process\\Pool\\Strategy->_jobProcessExited(Object(Neighborhoods\\Kojo\\Process\\Job))\n#6 /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Pool.php(46): Neighborhoods\\Kojo\\Process\\Pool\\Strategy->childProcessExited(Object(Neighborhoods\\Kojo\\Process\\Job))\n#7 /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Pool.php(28): Neighborhoods\\Kojo\\Process\\Pool->_childExitSignal(Object(Neighborhoods\\Kojo\\Process\\Signal\\Information))\n#8 [internal function]: Neighborhoods\\Kojo\\Process\\Pool->handleSignal(Object(Neighborhoods\\Kojo\\Process\\Signal\\Information))\n#9 /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Signal.php(44): call_user_func(Array, Object(Neighborhoods\\Kojo\\Process\\Signal\\Information))\n#10 /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Signal.php(36): Neighborhoods\\Kojo\\Process\\Signal->processSignalInformation(Object(Neighborhoods\\Kojo\\Process\\Signal\\Information))\n#11 /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Root.php(20): Neighborhoods\\Kojo\\Process\\Signal->processBufferedSignals()\n#12 /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Forked.php(32): Neighborhoods\\Kojo\\Process\\Root->_run()\n#13 /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Pool.php(85): Neighborhoods\\Kojo\\Process\\Forked->start()\n#14 /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Pool/Strategy/Server.php(49): Neighborhoods\\Kojo\\Process\\Pool->addChildProcess(Object(Neighborhoods\\Kojo\\Process\\Root))\n#15 /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/PoolAbstract.php(61): Neighborhoods\\Kojo\\Process\\Pool\\Strategy\\Server->initializePool()\n#16 /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Pool.php(18): Neighborhoods\\Kojo\\Process\\PoolAbstract->_initialize()\n#17 /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Pool/Server.php(27): Neighborhoods\\Kojo\\Process\\Pool->start()\n#18 /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/bin/kojo(36): Neighborhoods\\Kojo\\Process\\Pool\\Server->start()\n#19 {main}",
    "exception": {
      "class": "RuntimeException",
      "message": "Panicking job with ID[13362].",
      "code": 0,
      "file": "/var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Foreman.php:52",
      "trace": [
        "/var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Foreman.php:35",
        "/var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Job.php:29",
        "/var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Forked.php:32",
        "/var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Pool.php:85",
        "/var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Pool/Strategy.php:86",
        "/var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Pool/Strategy.php:19",
        "/var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Pool.php:46",
        "/var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Pool.php:28",
        "{\"function\":\"handleSignal\",\"class\":\"Neighborhoods\\\\Kojo\\\\Process\\\\Pool\",\"type\":\"->\",\"args\":[\"[object] (Neighborhoods\\\\Kojo\\\\Process\\\\Signal\\\\Information)\"]}",
        "/var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Signal.php:44",
        "/var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Signal.php:36",
        "/var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Root.php:20",
        "/var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Forked.php:32",
        "/var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Pool.php:85",
        "/var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Pool/Strategy/Server.php:49",
        "/var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/PoolAbstract.php:61",
        "/var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Pool.php:18",
        "/var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Pool/Server.php:27",
        "/var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/bin/kojo:36"
      ],
      "previous": {
        "class": "TypeError",
        "message": "Argument 1 passed to Neighborhoods\\KojoFitnessUseCase46\\V1\\Worker\\Delegate::onlyTakesIntegers() must be of the type integer, string given, called in /var/www/html/kojo_fitness.neighborhoods.com/UseCase46/src/V1/Worker/Delegate.php on line 33",
        "code": 0,
        "file": "/var/www/html/kojo_fitness.neighborhoods.com/UseCase46/src/V1/Worker/Delegate.php:45",
        "trace": [
          "/var/www/html/kojo_fitness.neighborhoods.com/UseCase46/src/V1/Worker/Delegate.php:33",
          "/var/www/html/kojo_fitness.neighborhoods.com/UseCase46/src/V1/Worker.php:55",
          "/var/www/html/kojo_fitness.neighborhoods.com/UseCase46/src/V1/Worker.php:25",
          "/var/www/html/kojo_fitness.neighborhoods.com/UseCase46/src/V1/Worker/Facade.php:21",
          "{\"function\":\"start\",\"class\":\"Neighborhoods\\\\KojoFitnessUseCase46\\\\V1\\\\Worker\\\\Facade\",\"type\":\"->\",\"args\":[]}",
          "/var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Foreman.php:89",
          "/var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Foreman.php:47",
          "/var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Foreman.php:35",
          "/var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Job.php:29",
          "/var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Forked.php:32",
          "/var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Pool.php:85",
          "/var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Pool/Strategy.php:86",
          "/var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Pool/Strategy.php:19",
          "/var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Pool.php:46",
          "/var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Pool.php:28",
          "{\"function\":\"handleSignal\",\"class\":\"Neighborhoods\\\\Kojo\\\\Process\\\\Pool\",\"type\":\"->\",\"args\":[\"[object] (Neighborhoods\\\\Kojo\\\\Process\\\\Signal\\\\Information)\"]}",
          "/var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Signal.php:44",
          "/var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Signal.php:36",
          "/var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Root.php:20",
          "/var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Forked.php:32",
          "/var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Pool.php:85",
          "/var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Pool/Strategy/Server.php:49",
          "/var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/PoolAbstract.php:61",
          "/var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Pool.php:18",
          "/var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/src/Process/Pool/Server.php:27",
          "/var/www/html/kojo_fitness.neighborhoods.com/UseCase46/vendor/neighborhoods/kojo/bin/kojo:36"
        ]
      }
    }
  },
  "context_json_last_error": 0
}
```

In ElasticSearch/Kibana this structure will index into the following fields:
<img width="766" alt="Screen Shot 2019-04-01 at 10 17 55 AM" src="https://user-images.githubusercontent.com/1881846/55339034-861e2d00-5467-11e9-9429-ec659d71fa14.png">

This will allow dashboards to be built that display the exception class and drill-down tables of the  exception messages:
<img width="1371" alt="Screen Shot 2019-04-01 at 10 19 58 AM" src="https://user-images.githubusercontent.com/1881846/55339752-ebbee900-5468-11e9-85aa-76ba9693ed79.png">
