### PR TITLE
HOTFIX | Modify watchdog to use one named redis connection

### DIFF
--- a/src/Process/Listener/Mutex/Redis.php
+++ b/src/Process/Listener/Mutex/Redis.php
@@ -3,17 +3,18 @@ declare(strict_types=1);
 
 namespace Neighborhoods\Kojo\Process\Listener\Mutex;
 
+use Neighborhoods\Kojo\Message\Broker\BrokerInterface;
 use Neighborhoods\Kojo\Process\Forked;
 use Neighborhoods\Kojo\Process\ListenerAbstract;
 use Neighborhoods\Kojo\Process\ListenerInterface;
 use Neighborhoods\Kojo\ProcessInterface;
-use Neighborhoods\Kojo\Redis\Factory;
+use Neighborhoods\Kojo\Redis\Repository;
 use RuntimeException;
 use Throwable;
 
 class Redis extends ListenerAbstract implements RedisInterface
 {
-    use Factory\AwareTrait;
+    use Repository\AwareTrait;
     public const PROP_REDIS = 'redis';
 
     protected function _run(): Forked
@@ -56,7 +57,7 @@ class Redis extends ListenerAbstract implements RedisInterface
     protected function _getRedis(): \Redis
     {
         if (!$this->_exists(self::PROP_REDIS)) {
-            $this->_create(self::PROP_REDIS, $this->_getRedisFactory()->create());
+            $this->_create(self::PROP_REDIS, $this->_getRedisRepository()->getById(BrokerInterface::class));
         }
 
         return $this->_read(self::PROP_REDIS);

--- a/src/Process/Listener/Mutex/Redis.yml
+++ b/src/Process/Listener/Mutex/Redis.yml
@@ -12,7 +12,7 @@ services:
       - [setBrokerTypeCollection, ['@neighborhoods.kojo.message.broker.type.collection-job']]
       - [setBrokerTypeCode, ['process.listener.mutex.redis']]
       - [setProcessPoolFactory, ['@process.pool.factory-empty']]
-      - [setRedisFactory, ['@redis.factory']]
+      - [setRedisRepository, ['@redis.repository']]
       - [setTitlePrefix, ['%process.title.prefix%']]
   process.listener.mutex.redis:
     alias: neighborhoods.kojo.process.listener.mutex.redis


### PR DESCRIPTION
The watchdog created two connections. The first was named with a process's UUID (and thus was used for determining if the process that held a mutex was still alive), and the second wasn't named but still used to execute the blocking push/pop command

Other actors trying to acquire a mutex would base their actions on the state of the first connection, which didn't offer the guarantee that the second connection did (i.e. that the worker would be killed if that connection was closed). This change uses the same connection for naming and the blocking operation (i.e. the intended behavior)

The choice of redis connection to use from the Repository is based on `\Neighborhoods\Kojo\Message\Broker\Redis::_getRedisClient()`