### PR TITLE
KOJO-154 | Include metadata in JobStateChange model

### DIFF
--- a/src/Data/Job/FromArrayBuilder.php
+++ b/src/Data/Job/FromArrayBuilder.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Kojo\Data\Job;
+
+use Neighborhoods\Kojo\Data;
+use Neighborhoods\Kojo\Data\JobInterface;
+
+class FromArrayBuilder implements FromArrayBuilderInterface
+{
+    /** @var array */
+    protected $record;
+
+    public function build() : JobInterface
+    {
+        $job = new Data\Job();
+        $record = $this->getRecord();
+
+        $job->setId($record['kojo_job_id']);
+        $job->setAssignedState($record['assigned_state']);
+        $job->setNextStateRequest($record['next_state_request']);
+        $job->setTypeCode($record['type_code']);
+        $job->setName($record['name']);
+        $job->setPriority($record['priority']);
+        $job->setImportance($record['importance']);
+        $job->setWorkAtDateTime($record['work_at_date_time']);
+        $job->setPreviousState($record['previous_state']);
+        $job->setWorkerUri($record['worker_uri']);
+        $job->setWorkerMethod($record['worker_method']);
+        $job->setCanWorkInParallel($record['can_work_in_parallel']);
+        $job->setLastTransitionInDateTime($record['last_transition_date_time']);
+        $job->setLastTransitionInMicroTime($record['last_transition_micro_time']);
+        $job->setTimesWorked($record['times_worked']);
+        $job->setTimesRetried($record['times_retried']);
+        $job->setTimesHeld($record['times_held']);
+        $job->setTimesCrashed($record['times_crashed']);
+        $job->setTimesPanicked($record['times_panicked']);
+        $job->setCreatedAtDateTime($record['created_at_date_time']);
+        $job->setCompletedAtDateTime($record['completed_at_date_time']);
+        $job->setDeleteAfterDateTime($record['delete_after_date_time']);
+
+        return $job;
+    }
+
+    protected function getRecord() : array
+    {
+        if ($this->record === null) {
+            throw new \LogicException('FromArrayBuilder record has not been set.');
+        }
+
+        return $this->record;
+    }
+
+    public function setRecord(array $record) : FromArrayBuilderInterface
+    {
+        if ($this->record !== null) {
+            throw new \LogicException('FromArrayBuilder record is already set.');
+        }
+
+        $this->record = $record;
+
+        return $this;
+    }
+}

--- a/src/Data/Job/FromArrayBuilder.php
+++ b/src/Data/Job/FromArrayBuilder.php
@@ -23,21 +23,35 @@ class FromArrayBuilder implements FromArrayBuilderInterface
         $job->setName($record['name']);
         $job->setPriority($record['priority']);
         $job->setImportance($record['importance']);
-        $job->setWorkAtDateTime($record['work_at_date_time']);
+        $job->setWorkAtDateTime(new \DateTime($record['work_at_date_time']));
         $job->setPreviousState($record['previous_state']);
         $job->setWorkerUri($record['worker_uri']);
         $job->setWorkerMethod($record['worker_method']);
         $job->setCanWorkInParallel($record['can_work_in_parallel']);
-        $job->setLastTransitionInDateTime($record['last_transition_date_time']);
-        $job->setLastTransitionInMicroTime($record['last_transition_micro_time']);
+        $job->setLastTransitionInDateTime(new \DateTime($record['last_transition_date_time']));
+        $job->setLastTransitionInMicroTime(
+            \DateTime::createFromFormat(
+                'U.u',
+                sprintf(
+                    '%s.%s',
+                    (int)($record['last_transition_micro_time'] / 1000000),
+                    $record['last_transition_micro_time'] % 1000000
+                )
+            )
+        );
         $job->setTimesWorked($record['times_worked']);
         $job->setTimesRetried($record['times_retried']);
         $job->setTimesHeld($record['times_held']);
         $job->setTimesCrashed($record['times_crashed']);
         $job->setTimesPanicked($record['times_panicked']);
-        $job->setCreatedAtDateTime($record['created_at_date_time']);
-        $job->setCompletedAtDateTime($record['completed_at_date_time']);
-        $job->setDeleteAfterDateTime($record['delete_after_date_time']);
+        $job->setCreatedAtDateTime(new \DateTime($record['created_at_date_time']));
+
+        if (isset($record['completed_at_date_time'])) {
+            $job->setCompletedAtDateTime(new \DateTime($record['completed_at_date_time']));
+        }
+        if (isset($record['delete_after_date_time'])) {
+            $job->setDeleteAfterDateTime(new \DateTime($record['delete_after_date_time']));
+        }
 
         return $job;
     }

--- a/src/Data/Job/FromArrayBuilder.yml
+++ b/src/Data/Job/FromArrayBuilder.yml
@@ -1,0 +1,4 @@
+services:
+  neighborhoods.kojo.data.job.from_array_builder:
+    class: Neighborhoods\Kojo\Data\Job\FromArrayBuilder
+    shared: false

--- a/src/Data/Job/FromArrayBuilder/AwareTrait.php
+++ b/src/Data/Job/FromArrayBuilder/AwareTrait.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Kojo\Data\Job\FromArrayBuilder;
+
+use Neighborhoods\Kojo\Data\Job\FromArrayBuilderInterface;
+
+/** @codeCoverageIgnore */
+trait AwareTrait
+{
+    protected $NeighborhoodsKojoDataJobFromArrayBuilder;
+
+    public function setDataJobFromArrayBuilder(FromArrayBuilderInterface $dataJobFromArrayBuilder) : self
+    {
+        if ($this->hasDataJobFromArrayBuilder()) {
+            throw new \LogicException('NeighborhoodsKojoDataJobFromArrayBuilder is already set.');
+        }
+        $this->NeighborhoodsKojoDataJobFromArrayBuilder = $dataJobFromArrayBuilder;
+
+        return $this;
+    }
+
+    protected function getDataJobFromArrayBuilder() : FromArrayBuilderInterface
+    {
+        if (!$this->hasDataJobFromArrayBuilder()) {
+            throw new \LogicException('NeighborhoodsKojoDataJobFromArrayBuilder is not set.');
+        }
+
+        return $this->NeighborhoodsKojoDataJobFromArrayBuilder;
+    }
+
+    protected function hasDataJobFromArrayBuilder() : bool
+    {
+        return isset($this->NeighborhoodsKojoDataJobFromArrayBuilder);
+    }
+
+    protected function unsetDataJobFromArrayBuilder() : self
+    {
+        if (!$this->hasDataJobFromArrayBuilder()) {
+            throw new \LogicException('NeighborhoodsKojoDataJobFromArrayBuilder is not set.');
+        }
+        unset($this->NeighborhoodsKojoDataJobFromArrayBuilder);
+
+        return $this;
+    }
+}

--- a/src/Data/Job/FromArrayBuilder/Factory.php
+++ b/src/Data/Job/FromArrayBuilder/Factory.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Kojo\Data\Job\FromArrayBuilder;
+
+use Neighborhoods\Kojo\Data\Job\FromArrayBuilderInterface;
+
+/** @codeCoverageIgnore */
+class Factory implements FactoryInterface
+{
+    use AwareTrait;
+
+    public function create() : FromArrayBuilderInterface
+    {
+        return clone $this->getDataJobFromArrayBuilder();
+    }
+}

--- a/src/Data/Job/FromArrayBuilder/Factory.yml
+++ b/src/Data/Job/FromArrayBuilder/Factory.yml
@@ -1,0 +1,5 @@
+services:
+  neighborhoods.kojo.data.job.from_array_builder.factory:
+    class: Neighborhoods\Kojo\Data\Job\FromArrayBuilder\Factory
+    calls:
+      - [setDataJobFromArrayBuilder, ['@neighborhoods.kojo.data.job.from_array_builder']]

--- a/src/Data/Job/FromArrayBuilder/Factory/AwareTrait.php
+++ b/src/Data/Job/FromArrayBuilder/Factory/AwareTrait.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Kojo\Data\Job\FromArrayBuilder\Factory;
+
+use Neighborhoods\Kojo\Data\Job\FromArrayBuilder\FactoryInterface;
+
+/** @codeCoverageIgnore */
+trait AwareTrait
+{
+    protected $NeighborhoodsKojoDataJobFromArrayBuilderFactory;
+
+    public function setDataJobFromArrayBuilderFactory(FactoryInterface $dataJobFromArrayBuilderFactory) : self
+    {
+        if ($this->hasDataJobFromArrayBuilderFactory()) {
+            throw new \LogicException('NeighborhoodsKojoDataJobFromArrayBuilderFactory is already set.');
+        }
+        $this->NeighborhoodsKojoDataJobFromArrayBuilderFactory = $dataJobFromArrayBuilderFactory;
+
+        return $this;
+    }
+
+    protected function getDataJobFromArrayBuilderFactory() : FactoryInterface
+    {
+        if (!$this->hasDataJobFromArrayBuilderFactory()) {
+            throw new \LogicException('NeighborhoodsKojoDataJobFromArrayBuilderFactory is not set.');
+        }
+
+        return $this->NeighborhoodsKojoDataJobFromArrayBuilderFactory;
+    }
+
+    protected function hasDataJobFromArrayBuilderFactory() : bool
+    {
+        return isset($this->NeighborhoodsKojoDataJobFromArrayBuilderFactory);
+    }
+
+    protected function unsetDataJobFromArrayBuilderFactory() : self
+    {
+        if (!$this->hasDataJobFromArrayBuilderFactory()) {
+            throw new \LogicException('NeighborhoodsKojoDataJobFromArrayBuilderFactory is not set.');
+        }
+        unset($this->NeighborhoodsKojoDataJobFromArrayBuilderFactory);
+
+        return $this;
+    }
+}

--- a/src/Data/Job/FromArrayBuilder/FactoryInterface.php
+++ b/src/Data/Job/FromArrayBuilder/FactoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Kojo\Data\Job\FromArrayBuilder;
+
+use Neighborhoods\Kojo\Data\Job\FromArrayBuilderInterface;
+
+/** @codeCoverageIgnore */
+interface FactoryInterface
+{
+    public function create() : FromArrayBuilderInterface;
+}

--- a/src/Data/Job/FromArrayBuilderInterface.php
+++ b/src/Data/Job/FromArrayBuilderInterface.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Kojo\Data\Job;
+
+use Neighborhoods\Kojo\Data\JobInterface;
+
+interface FromArrayBuilderInterface
+{
+    public function build() : JobInterface;
+
+    public function setRecord(array $record) : FromArrayBuilderInterface;
+}

--- a/src/JobStateChange/Builder.php
+++ b/src/JobStateChange/Builder.php
@@ -15,11 +15,11 @@ class Builder implements BuilderInterface
 
     public function build() : JobStateChangeInterface
     {
-        $JobStateChange = $this->getJobStateChangeFactory()->create();
+        $jobStateChange = $this->getJobStateChangeFactory()->create();
         $record = $this->getRecord();
 
-        $JobStateChange->setId((int)$record[JobStateChangeInterface::PROP_ID]);
-        $JobStateChange->setData(
+        $jobStateChange->setId((int)$record[JobStateChangeInterface::PROP_ID]);
+        $jobStateChange->setData(
             $this
                 ->getJobStateChangeDataBuilderFactory()
                 ->create()
@@ -27,7 +27,7 @@ class Builder implements BuilderInterface
                 ->build()
         );
 
-        return $JobStateChange;
+        return $jobStateChange;
     }
 
     protected function getRecord() : array

--- a/src/JobStateChange/Data.php
+++ b/src/JobStateChange/Data.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Neighborhoods\Kojo\JobStateChange;
 
+use Neighborhoods\Kojo\Process\Pool\Logger\Message;
+
 class Data implements DataInterface
 {
     /** @var string */
@@ -11,8 +13,8 @@ class Data implements DataInterface
     protected $new_state;
     /** @var \DateTimeInterface */
     protected $timestamp;
-    /** @var ? */
-    // protected $metadata;
+    /** @var Message\MetadataInterface */
+    protected $metadata;
 
     public function getOldState() : string
     {
@@ -62,6 +64,23 @@ class Data implements DataInterface
             throw new \LogicException('Data timestamp is already set.');
         }
         $this->timestamp = $timestamp;
+        return $this;
+    }
+
+    public function getMetadata() : Message\MetadataInterface
+    {
+        if ($this->metadata === null) {
+            throw new \LogicException('Data metadata has not been set.');
+        }
+        return $this->metadata;
+    }
+
+    public function setMetadata(Message\MetadataInterface $metadata) : DataInterface
+    {
+        if ($this->metadata !== null) {
+            throw new \LogicException('Data metadata is already set.');
+        }
+        $this->metadata = $metadata;
         return $this;
     }
 }

--- a/src/JobStateChange/Data/Builder.php
+++ b/src/JobStateChange/Data/Builder.php
@@ -19,6 +19,7 @@ class Builder implements BuilderInterface
         $data->setOldState($record[DataInterface::PROP_OLD_STATE]);
         $data->setNewState($record[DataInterface::PROP_NEW_STATE]);
         $data->setTimestamp(new \DateTimeImmutable($record[DataInterface::PROP_TIMESTAMP]));
+        // use a "from RDBMS" builder for the metadata
 
         return $data;
     }

--- a/src/JobStateChange/Data/Builder.php
+++ b/src/JobStateChange/Data/Builder.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 namespace Neighborhoods\Kojo\JobStateChange\Data;
 
 use Neighborhoods\Kojo\JobStateChange\DataInterface;
+use Neighborhoods\Kojo\Process\Pool\Logger\Message\Metadata;
 
 class Builder implements BuilderInterface
 {
+    use Metadata\FromArrayBuilder\Factory\AwareTrait;
     use Factory\AwareTrait;
     /** @var array */
     protected $record;
@@ -19,7 +21,14 @@ class Builder implements BuilderInterface
         $data->setOldState($record[DataInterface::PROP_OLD_STATE]);
         $data->setNewState($record[DataInterface::PROP_NEW_STATE]);
         $data->setTimestamp(new \DateTimeImmutable($record[DataInterface::PROP_TIMESTAMP]));
-        // use a "from RDBMS" builder for the metadata
+
+        $metadata = $this
+            ->getProcessPoolLoggerMessageMetadataFromArrayBuilderFactory()
+            ->create()
+            ->setRecord($record[DataInterface::PROP_METADATA])
+            ->build();
+
+        $data->setMetadata($metadata);
 
         return $data;
     }

--- a/src/JobStateChange/Data/Builder.yml
+++ b/src/JobStateChange/Data/Builder.yml
@@ -5,6 +5,7 @@ services:
     shared: false
     calls:
       - [setJobStateChangeDataFactory, ['@job_state_change.data.factory']]
+      - [setProcessPoolLoggerMessageMetadataFromArrayBuilderFactory, ['@neighborhoods.kojo.process.pool.logger.message.metadata.from_array_builder.factory']]
   job_state_change.data.builder:
     alias: neighborhoods.kojo.job_state_change.data.builder
     public: false

--- a/src/JobStateChange/DataInterface.php
+++ b/src/JobStateChange/DataInterface.php
@@ -3,12 +3,14 @@ declare(strict_types=1);
 
 namespace Neighborhoods\Kojo\JobStateChange;
 
+use Neighborhoods\Kojo\Process\Pool\Logger\Message;
+
 interface DataInterface
 {
     public const PROP_OLD_STATE = 'old_state';
     public const PROP_NEW_STATE = 'new_state';
     public const PROP_TIMESTAMP = 'timestamp';
-    // public const PROP_METADATA = 'metadata';
+    public const PROP_METADATA = 'metadata';
 
     public function getOldState() : string;
     public function setOldState(string $old_state) : DataInterface;
@@ -18,4 +20,7 @@ interface DataInterface
 
     public function getTimestamp() : \DateTimeInterface;
     public function setTimestamp(\DateTimeInterface $timestamp) : DataInterface;
+
+    public function getMetadata() : Message\MetadataInterface;
+    public function setMetadata(Message\MetadataInterface $metadata) : DataInterface;
 }

--- a/src/Process/Pool/Logger/Message/Metadata/FromArrayBuilder.php
+++ b/src/Process/Pool/Logger/Message/Metadata/FromArrayBuilder.php
@@ -1,0 +1,67 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Kojo\Process\Pool\Logger\Message\Metadata;
+
+use Neighborhoods\Kojo\Process\Pool\Logger\Message;
+use Neighborhoods\Kojo\Data;
+
+class FromArrayBuilder implements FromArrayBuilderInterface
+{
+    use Message\SerializableProcess\FromArrayBuilder\Factory\AwareTrait;
+    use Data\Job\FromArrayBuilder\Factory\AwareTrait;
+    use Message\Metadata\Host\FromArrayBuilder\Factory\AwareTrait;
+    use Factory\AwareTrait;
+
+    /** @var array */
+    protected $record;
+
+    public function build() : Message\MetadataInterface
+    {
+        $metadata = $this->getProcessPoolLoggerMessageMetadataFactory()->create();
+        $record = $this->getRecord();
+
+        $serializableProcess = $this
+            ->getProcessPoolLoggerMessageSerializableProcessFromArrayBuilderFactory()
+            ->create()
+            ->setRecord($record['process'])
+            ->build();
+        $metadata->setProcess($serializableProcess);
+
+        $job = $this
+            ->getDataJobFromArrayBuilderFactory()
+            ->create()
+            ->setRecord($record['job'])
+            ->build();
+        $metadata->setJob($job);
+
+        $host = $this
+            ->getProcessPoolLoggerMessageMetadataHostFromArrayBuilderFactory()
+            ->create()
+            ->setRecord($record['host'])
+            ->build();
+        $metadata->setHost($host);
+
+        return $metadata;
+    }
+
+    protected function getRecord() : array
+    {
+        if ($this->record === null) {
+            throw new \LogicException('FromArrayBuilder record has not been set.');
+        }
+
+        return $this->record;
+    }
+
+    public function setRecord(array $record) : FromArrayBuilderInterface
+    {
+        if ($this->record !== null) {
+            throw new \LogicException('FromArrayBuilder record is already set.');
+        }
+
+        $this->record = $record;
+
+        return $this;
+    }
+}

--- a/src/Process/Pool/Logger/Message/Metadata/FromArrayBuilder.yml
+++ b/src/Process/Pool/Logger/Message/Metadata/FromArrayBuilder.yml
@@ -1,0 +1,9 @@
+services:
+  neighborhoods.kojo.process.pool.logger.message.metadata.from_array_builder:
+    class: Neighborhoods\Kojo\Process\Pool\Logger\Message\Metadata\FromArrayBuilder
+    shared: false
+    calls:
+      - [setProcessPoolLoggerMessageMetadataFactory, ['@neighborhoods.kojo.process.pool.logger.message.metadata.factory']]
+      - [setProcessPoolLoggerMessageSerializableProcessFromArrayBuilderFactory, ['@neighborhoods.kojo.process.pool.logger.message.serializable_process.from_array_builder.factory']]
+      - [setDataJobFromArrayBuilderFactory, ['@neighborhoods.kojo.data.job.from_array_builder.factory']]
+      - [setProcessPoolLoggerMessageMetadataHostFromArrayBuilderFactory, ['@neighborhoods.kojo.process.pool.logger.message.metadata.host.from_array_builder.factory']]

--- a/src/Process/Pool/Logger/Message/Metadata/FromArrayBuilder/AwareTrait.php
+++ b/src/Process/Pool/Logger/Message/Metadata/FromArrayBuilder/AwareTrait.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Kojo\Process\Pool\Logger\Message\Metadata\FromArrayBuilder;
+
+use Neighborhoods\Kojo\Process\Pool\Logger\Message\Metadata\FromArrayBuilderInterface;
+
+/** @codeCoverageIgnore */
+trait AwareTrait
+{
+    protected $NeighborhoodsKojoProcessPoolLoggerMessageMetadataFromArrayBuilder;
+
+    public function setProcessPoolLoggerMessageMetadataFromArrayBuilder(FromArrayBuilderInterface $processPoolLoggerMessageMetadataFromArrayBuilder) : self
+    {
+        if ($this->hasProcessPoolLoggerMessageMetadataFromArrayBuilder()) {
+            throw new \LogicException('NeighborhoodsKojoProcessPoolLoggerMessageMetadataFromArrayBuilder is already set.');
+        }
+        $this->NeighborhoodsKojoProcessPoolLoggerMessageMetadataFromArrayBuilder = $processPoolLoggerMessageMetadataFromArrayBuilder;
+
+        return $this;
+    }
+
+    protected function getProcessPoolLoggerMessageMetadataFromArrayBuilder() : FromArrayBuilderInterface
+    {
+        if (!$this->hasProcessPoolLoggerMessageMetadataFromArrayBuilder()) {
+            throw new \LogicException('NeighborhoodsKojoProcessPoolLoggerMessageMetadataFromArrayBuilder is not set.');
+        }
+
+        return $this->NeighborhoodsKojoProcessPoolLoggerMessageMetadataFromArrayBuilder;
+    }
+
+    protected function hasProcessPoolLoggerMessageMetadataFromArrayBuilder() : bool
+    {
+        return isset($this->NeighborhoodsKojoProcessPoolLoggerMessageMetadataFromArrayBuilder);
+    }
+
+    protected function unsetProcessPoolLoggerMessageMetadataFromArrayBuilder() : self
+    {
+        if (!$this->hasProcessPoolLoggerMessageMetadataFromArrayBuilder()) {
+            throw new \LogicException('NeighborhoodsKojoProcessPoolLoggerMessageMetadataFromArrayBuilder is not set.');
+        }
+        unset($this->NeighborhoodsKojoProcessPoolLoggerMessageMetadataFromArrayBuilder);
+
+        return $this;
+    }
+}

--- a/src/Process/Pool/Logger/Message/Metadata/FromArrayBuilder/Factory.php
+++ b/src/Process/Pool/Logger/Message/Metadata/FromArrayBuilder/Factory.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Kojo\Process\Pool\Logger\Message\Metadata\FromArrayBuilder;
+
+use Neighborhoods\Kojo\Process\Pool\Logger\Message\Metadata\FromArrayBuilderInterface;
+
+/** @codeCoverageIgnore */
+class Factory implements FactoryInterface
+{
+    use AwareTrait;
+
+    public function create() : FromArrayBuilderInterface
+    {
+        return clone $this->getProcessPoolLoggerMessageMetadataFromArrayBuilder();
+    }
+}

--- a/src/Process/Pool/Logger/Message/Metadata/FromArrayBuilder/Factory.yml
+++ b/src/Process/Pool/Logger/Message/Metadata/FromArrayBuilder/Factory.yml
@@ -1,0 +1,5 @@
+services:
+  neighborhoods.kojo.process.pool.logger.message.metadata.from_array_builder.factory:
+    class: Neighborhoods\Kojo\Process\Pool\Logger\Message\Metadata\FromArrayBuilder\Factory
+    calls:
+      - [setProcessPoolLoggerMessageMetadataFromArrayBuilder, ['@neighborhoods.kojo.process.pool.logger.message.metadata.from_array_builder']]

--- a/src/Process/Pool/Logger/Message/Metadata/FromArrayBuilder/Factory/AwareTrait.php
+++ b/src/Process/Pool/Logger/Message/Metadata/FromArrayBuilder/Factory/AwareTrait.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Kojo\Process\Pool\Logger\Message\Metadata\FromArrayBuilder\Factory;
+
+use Neighborhoods\Kojo\Process\Pool\Logger\Message\Metadata\FromArrayBuilder\FactoryInterface;
+
+/** @codeCoverageIgnore */
+trait AwareTrait
+{
+    protected $NeighborhoodsKojoProcessPoolLoggerMessageMetadataFromArrayBuilderFactory;
+
+    public function setProcessPoolLoggerMessageMetadataFromArrayBuilderFactory(FactoryInterface $processPoolLoggerMessageMetadataFromArrayBuilderFactory) : self
+    {
+        if ($this->hasProcessPoolLoggerMessageMetadataFromArrayBuilderFactory()) {
+            throw new \LogicException('NeighborhoodsKojoProcessPoolLoggerMessageMetadataFromArrayBuilderFactory is already set.');
+        }
+        $this->NeighborhoodsKojoProcessPoolLoggerMessageMetadataFromArrayBuilderFactory = $processPoolLoggerMessageMetadataFromArrayBuilderFactory;
+
+        return $this;
+    }
+
+    protected function getProcessPoolLoggerMessageMetadataFromArrayBuilderFactory() : FactoryInterface
+    {
+        if (!$this->hasProcessPoolLoggerMessageMetadataFromArrayBuilderFactory()) {
+            throw new \LogicException('NeighborhoodsKojoProcessPoolLoggerMessageMetadataFromArrayBuilderFactory is not set.');
+        }
+
+        return $this->NeighborhoodsKojoProcessPoolLoggerMessageMetadataFromArrayBuilderFactory;
+    }
+
+    protected function hasProcessPoolLoggerMessageMetadataFromArrayBuilderFactory() : bool
+    {
+        return isset($this->NeighborhoodsKojoProcessPoolLoggerMessageMetadataFromArrayBuilderFactory);
+    }
+
+    protected function unsetProcessPoolLoggerMessageMetadataFromArrayBuilderFactory() : self
+    {
+        if (!$this->hasProcessPoolLoggerMessageMetadataFromArrayBuilderFactory()) {
+            throw new \LogicException('NeighborhoodsKojoProcessPoolLoggerMessageMetadataFromArrayBuilderFactory is not set.');
+        }
+        unset($this->NeighborhoodsKojoProcessPoolLoggerMessageMetadataFromArrayBuilderFactory);
+
+        return $this;
+    }
+}

--- a/src/Process/Pool/Logger/Message/Metadata/FromArrayBuilder/FactoryInterface.php
+++ b/src/Process/Pool/Logger/Message/Metadata/FromArrayBuilder/FactoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Kojo\Process\Pool\Logger\Message\Metadata\FromArrayBuilder;
+
+use Neighborhoods\Kojo\Process\Pool\Logger\Message\Metadata\FromArrayBuilderInterface;
+
+/** @codeCoverageIgnore */
+interface FactoryInterface
+{
+    public function create() : FromArrayBuilderInterface;
+}

--- a/src/Process/Pool/Logger/Message/Metadata/FromArrayBuilderInterface.php
+++ b/src/Process/Pool/Logger/Message/Metadata/FromArrayBuilderInterface.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Kojo\Process\Pool\Logger\Message\Metadata;
+
+use Neighborhoods\Kojo\Process\Pool\Logger\Message\MetadataInterface;
+
+interface FromArrayBuilderInterface
+{
+    public function setRecord(array $record) : FromArrayBuilderInterface;
+
+    public function build() : MetadataInterface;
+}

--- a/src/Process/Pool/Logger/Message/Metadata/Host.php
+++ b/src/Process/Pool/Logger/Message/Metadata/Host.php
@@ -18,16 +18,39 @@ class Host implements HostInterface
         return gethostname();
     }
 
+    public function setHostName(string $host_name) : HostInterface
+    {
+        if ($this->host_name !== null) {
+            throw new \LogicException('Host host_name is already set.');
+        }
+        $this->host_name = $host_name;
+        return $this;
+    }
+
     public function getLoadAverage() : float
     {
         return (float)current(sys_getloadavg());
     }
 
+    public function setLoadAverage(float $load_average) : HostInterface
+    {
+        if ($this->load_average !== null) {
+            throw new \LogicException('Host load_average is already set.');
+        }
+        $this->load_average = $load_average;
+        return $this;
+    }
+
     public function jsonSerialize()
     {
         $data = get_object_vars($this);
-        $data[self::KEY_HOST_NAME] = $this->getHostName();
-        $data[self::KEY_LOAD_AVERAGE] = $this->getLoadAverage();
+
+        if (!isset($data[self::KEY_HOST_NAME])) {
+            $data[self::KEY_HOST_NAME] = $this->getHostName();
+        }
+        if (!isset($data[self::KEY_LOAD_AVERAGE])) {
+            $data[self::KEY_LOAD_AVERAGE] = $this->getLoadAverage();
+        }
 
         return $data;
     }

--- a/src/Process/Pool/Logger/Message/Metadata/Host/FromArrayBuilder.php
+++ b/src/Process/Pool/Logger/Message/Metadata/Host/FromArrayBuilder.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Kojo\Process\Pool\Logger\Message\Metadata\Host;
+
+use Neighborhoods\Kojo\Process\Pool\Logger\Message\Metadata;
+
+class FromArrayBuilder implements FromArrayBuilderInterface
+{
+    /** @var array */
+    protected $record;
+
+    public function build() : Metadata\HostInterface
+    {
+        $host = new Metadata\Host();
+        $record = $this->getRecord();
+
+        $host->setHostName($record['host_name']);
+        $host->setLoadAverage($record['load_average']);
+
+        return $host;
+    }
+
+    protected function getRecord() : array
+    {
+        if ($this->record === null) {
+            throw new \LogicException('FromArrayBuilder record has not been set.');
+        }
+
+        return $this->record;
+    }
+
+    public function setRecord(array $record) : FromArrayBuilderInterface
+    {
+        if ($this->record !== null) {
+            throw new \LogicException('FromArrayBuilder record is already set.');
+        }
+
+        $this->record = $record;
+
+        return $this;
+    }
+}

--- a/src/Process/Pool/Logger/Message/Metadata/Host/FromArrayBuilder.yml
+++ b/src/Process/Pool/Logger/Message/Metadata/Host/FromArrayBuilder.yml
@@ -1,0 +1,4 @@
+services:
+  neighborhoods.kojo.process.pool.logger.message.metadata.host.from_array_builder:
+    class: Neighborhoods\Kojo\Process\Pool\Logger\Message\Metadata\Host\FromArrayBuilder
+    shared: false

--- a/src/Process/Pool/Logger/Message/Metadata/Host/FromArrayBuilder/AwareTrait.php
+++ b/src/Process/Pool/Logger/Message/Metadata/Host/FromArrayBuilder/AwareTrait.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Kojo\Process\Pool\Logger\Message\Metadata\Host\FromArrayBuilder;
+
+use Neighborhoods\Kojo\Process\Pool\Logger\Message\Metadata\Host\FromArrayBuilderInterface;
+
+/** @codeCoverageIgnore */
+trait AwareTrait
+{
+    protected $NeighborhoodsKojoProcessPoolLoggerMessageMetadataHostFromArrayBuilder;
+
+    public function setProcessPoolLoggerMessageMetadataHostFromArrayBuilder(FromArrayBuilderInterface $processPoolLoggerMessageMetadataHostFromArrayBuilder) : self
+    {
+        if ($this->hasProcessPoolLoggerMessageMetadataHostFromArrayBuilder()) {
+            throw new \LogicException('NeighborhoodsKojoProcessPoolLoggerMessageMetadataHostFromArrayBuilder is already set.');
+        }
+        $this->NeighborhoodsKojoProcessPoolLoggerMessageMetadataHostFromArrayBuilder = $processPoolLoggerMessageMetadataHostFromArrayBuilder;
+
+        return $this;
+    }
+
+    protected function getProcessPoolLoggerMessageMetadataHostFromArrayBuilder() : FromArrayBuilderInterface
+    {
+        if (!$this->hasProcessPoolLoggerMessageMetadataHostFromArrayBuilder()) {
+            throw new \LogicException('NeighborhoodsKojoProcessPoolLoggerMessageMetadataHostFromArrayBuilder is not set.');
+        }
+
+        return $this->NeighborhoodsKojoProcessPoolLoggerMessageMetadataHostFromArrayBuilder;
+    }
+
+    protected function hasProcessPoolLoggerMessageMetadataHostFromArrayBuilder() : bool
+    {
+        return isset($this->NeighborhoodsKojoProcessPoolLoggerMessageMetadataHostFromArrayBuilder);
+    }
+
+    protected function unsetProcessPoolLoggerMessageMetadataHostFromArrayBuilder() : self
+    {
+        if (!$this->hasProcessPoolLoggerMessageMetadataHostFromArrayBuilder()) {
+            throw new \LogicException('NeighborhoodsKojoProcessPoolLoggerMessageMetadataHostFromArrayBuilder is not set.');
+        }
+        unset($this->NeighborhoodsKojoProcessPoolLoggerMessageMetadataHostFromArrayBuilder);
+
+        return $this;
+    }
+}

--- a/src/Process/Pool/Logger/Message/Metadata/Host/FromArrayBuilder/Factory.php
+++ b/src/Process/Pool/Logger/Message/Metadata/Host/FromArrayBuilder/Factory.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Kojo\Process\Pool\Logger\Message\Metadata\Host\FromArrayBuilder;
+
+use Neighborhoods\Kojo\Process\Pool\Logger\Message\Metadata\Host\FromArrayBuilderInterface;
+
+/** @codeCoverageIgnore */
+class Factory implements FactoryInterface
+{
+    use AwareTrait;
+
+    public function create() : FromArrayBuilderInterface
+    {
+        return clone $this->getProcessPoolLoggerMessageMetadataHostFromArrayBuilder();
+    }
+}

--- a/src/Process/Pool/Logger/Message/Metadata/Host/FromArrayBuilder/Factory.yml
+++ b/src/Process/Pool/Logger/Message/Metadata/Host/FromArrayBuilder/Factory.yml
@@ -1,0 +1,5 @@
+services:
+  neighborhoods.kojo.process.pool.logger.message.metadata.host.from_array_builder.factory:
+    class: Neighborhoods\Kojo\Process\Pool\Logger\Message\Metadata\Host\FromArrayBuilder\Factory
+    calls:
+      - [setProcessPoolLoggerMessageMetadataHostFromArrayBuilder, ['@neighborhoods.kojo.process.pool.logger.message.metadata.host.from_array_builder']]

--- a/src/Process/Pool/Logger/Message/Metadata/Host/FromArrayBuilder/Factory/AwareTrait.php
+++ b/src/Process/Pool/Logger/Message/Metadata/Host/FromArrayBuilder/Factory/AwareTrait.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Kojo\Process\Pool\Logger\Message\Metadata\Host\FromArrayBuilder\Factory;
+
+use Neighborhoods\Kojo\Process\Pool\Logger\Message\Metadata\Host\FromArrayBuilder\FactoryInterface;
+
+/** @codeCoverageIgnore */
+trait AwareTrait
+{
+    protected $NeighborhoodsKojoProcessPoolLoggerMessageMetadataHostFromArrayBuilderFactory;
+
+    public function setProcessPoolLoggerMessageMetadataHostFromArrayBuilderFactory(FactoryInterface $processPoolLoggerMessageMetadataHostFromArrayBuilderFactory) : self
+    {
+        if ($this->hasProcessPoolLoggerMessageMetadataHostFromArrayBuilderFactory()) {
+            throw new \LogicException('NeighborhoodsKojoProcessPoolLoggerMessageMetadataHostFromArrayBuilderFactory is already set.');
+        }
+        $this->NeighborhoodsKojoProcessPoolLoggerMessageMetadataHostFromArrayBuilderFactory = $processPoolLoggerMessageMetadataHostFromArrayBuilderFactory;
+
+        return $this;
+    }
+
+    protected function getProcessPoolLoggerMessageMetadataHostFromArrayBuilderFactory() : FactoryInterface
+    {
+        if (!$this->hasProcessPoolLoggerMessageMetadataHostFromArrayBuilderFactory()) {
+            throw new \LogicException('NeighborhoodsKojoProcessPoolLoggerMessageMetadataHostFromArrayBuilderFactory is not set.');
+        }
+
+        return $this->NeighborhoodsKojoProcessPoolLoggerMessageMetadataHostFromArrayBuilderFactory;
+    }
+
+    protected function hasProcessPoolLoggerMessageMetadataHostFromArrayBuilderFactory() : bool
+    {
+        return isset($this->NeighborhoodsKojoProcessPoolLoggerMessageMetadataHostFromArrayBuilderFactory);
+    }
+
+    protected function unsetProcessPoolLoggerMessageMetadataHostFromArrayBuilderFactory() : self
+    {
+        if (!$this->hasProcessPoolLoggerMessageMetadataHostFromArrayBuilderFactory()) {
+            throw new \LogicException('NeighborhoodsKojoProcessPoolLoggerMessageMetadataHostFromArrayBuilderFactory is not set.');
+        }
+        unset($this->NeighborhoodsKojoProcessPoolLoggerMessageMetadataHostFromArrayBuilderFactory);
+
+        return $this;
+    }
+}

--- a/src/Process/Pool/Logger/Message/Metadata/Host/FromArrayBuilder/FactoryInterface.php
+++ b/src/Process/Pool/Logger/Message/Metadata/Host/FromArrayBuilder/FactoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Kojo\Process\Pool\Logger\Message\Metadata\Host\FromArrayBuilder;
+
+use Neighborhoods\Kojo\Process\Pool\Logger\Message\Metadata\Host\FromArrayBuilderInterface;
+
+/** @codeCoverageIgnore */
+interface FactoryInterface
+{
+    public function create() : FromArrayBuilderInterface;
+}

--- a/src/Process/Pool/Logger/Message/Metadata/Host/FromArrayBuilderInterface.php
+++ b/src/Process/Pool/Logger/Message/Metadata/Host/FromArrayBuilderInterface.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Kojo\Process\Pool\Logger\Message\Metadata\Host;
+
+use Neighborhoods\Kojo\Process\Pool\Logger\Message\Metadata\HostInterface;
+
+interface FromArrayBuilderInterface
+{
+    public function build() : HostInterface;
+
+    public function setRecord(array $record) : FromArrayBuilderInterface;
+}

--- a/src/Process/Pool/Logger/Message/SerializableProcess.php
+++ b/src/Process/Pool/Logger/Message/SerializableProcess.php
@@ -128,7 +128,16 @@ class SerializableProcess implements SerializableProcessInterface
 
     public function getMemoryUsageBytes() : int
     {
-        return  memory_get_usage();
+        return memory_get_usage();
+    }
+
+    public function setMemoryUsageBytes(int $memory_usage_bytes) : SerializableProcessInterface
+    {
+        if ($this->memory_usage_bytes !== null) {
+            throw new \LogicException('SerializableProcess memory_usage_bytes is already set.');
+        }
+        $this->memory_usage_bytes = $memory_usage_bytes;
+        return $this;
     }
 
     public function getMemoryPeakUsageBytes() : int
@@ -136,17 +145,43 @@ class SerializableProcess implements SerializableProcessInterface
         return memory_get_peak_usage();
     }
 
+    public function setMemoryPeakUsageBytes(int $memory_peak_usage_bytes) : SerializableProcessInterface
+    {
+        if ($this->memory_peak_usage_bytes !== null) {
+            throw new \LogicException('SerializableProcess memory_peak_usage_bytes is already set.');
+        }
+        $this->memory_peak_usage_bytes = $memory_peak_usage_bytes;
+        return $this;
+    }
+
     public function getMemoryLimitBytes() : int
     {
         return $this->dataUnitToBytes(ini_get('memory_limit'));
     }
 
+    public function setMemoryLimitBytes(int $memory_limit_bytes) : SerializableProcessInterface
+    {
+        if ($this->memory_limit_bytes !== null) {
+            throw new \LogicException('SerializableProcess memory_limit_bytes is already set.');
+        }
+        $this->memory_limit_bytes = $memory_limit_bytes;
+        return $this;
+    }
+
     public function jsonSerialize()
     {
         $data = get_object_vars($this);
-        $data[self::KEY_MEMORY_USAGE_BYTES]= $this->getMemoryUsageBytes();
-        $data[self::KEY_MEMORY_PEAK_USAGE_BYTES]= $this->getMemoryPeakUsageBytes();
-        $data[self::KEY_MEMORY_LIMIT_BYTES]= $this->getMemoryLimitBytes();
+
+        if (!isset($data[self::KEY_MEMORY_USAGE_BYTES])) {
+            $data[self::KEY_MEMORY_USAGE_BYTES] = $this->getMemoryUsageBytes();
+        }
+        if (!isset($data[self::KEY_MEMORY_PEAK_USAGE_BYTES])) {
+            $data[self::KEY_MEMORY_PEAK_USAGE_BYTES] = $this->getMemoryPeakUsageBytes();
+        }
+        if (!isset($data[self::KEY_MEMORY_LIMIT_BYTES])) {
+            $data[self::KEY_MEMORY_LIMIT_BYTES] = $this->getMemoryLimitBytes();
+        }
+
         return $data;
     }
 

--- a/src/Process/Pool/Logger/Message/SerializableProcess/FromArrayBuilder.php
+++ b/src/Process/Pool/Logger/Message/SerializableProcess/FromArrayBuilder.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Kojo\Process\Pool\Logger\Message\SerializableProcess;
+
+use Neighborhoods\Kojo\Process\Pool\Logger\Message\SerializableProcessInterface;
+
+class FromArrayBuilder implements FromArrayBuilderInterface
+{
+    use Factory\AwareTrait;
+
+    /** @var array */
+    protected $record;
+
+    public function build() : SerializableProcessInterface
+    {
+        $serializableProcess = $this->getProcessPoolLoggerMessageSerializableProcessFactory()->create();
+        $record = $this->getRecord();
+
+        $serializableProcess->setProcessId($record['process_id']);
+        $serializableProcess->setParentProcessId($record['parent_process_id']);
+        $serializableProcess->setPath($record['path']);
+        $serializableProcess->setUuid($record['uuid']);
+        $serializableProcess->setTypeCode($record['type_code']);
+        $serializableProcess->setMemoryUsageBytes($record['memory_usage_bytes']);
+        $serializableProcess->setMemoryPeakUsageBytes($record['memory_peak_usage_bytes']);
+        $serializableProcess->setMemoryLimitBytes($record['memory_limit_bytes']);
+
+        return $serializableProcess;
+    }
+
+    protected function getRecord() : array
+    {
+        if ($this->record === null) {
+            throw new \LogicException('FromArrayBuilder record has not been set.');
+        }
+
+        return $this->record;
+    }
+
+    public function setRecord(array $record) : FromArrayBuilderInterface
+    {
+        if ($this->record !== null) {
+            throw new \LogicException('FromArrayBuilder record is already set.');
+        }
+
+        $this->record = $record;
+
+        return $this;
+    }
+}

--- a/src/Process/Pool/Logger/Message/SerializableProcess/FromArrayBuilder.yml
+++ b/src/Process/Pool/Logger/Message/SerializableProcess/FromArrayBuilder.yml
@@ -2,3 +2,5 @@ services:
   neighborhoods.kojo.process.pool.logger.message.serializable_process.from_array_builder:
     class: Neighborhoods\Kojo\Process\Pool\Logger\Message\SerializableProcess\FromArrayBuilder
     shared: false
+    calls:
+      - [setProcessPoolLoggerMessageSerializableProcessFactory, ['@neighborhoods.kojo.process.pool.logger.message.serializable_process.factory']]

--- a/src/Process/Pool/Logger/Message/SerializableProcess/FromArrayBuilder.yml
+++ b/src/Process/Pool/Logger/Message/SerializableProcess/FromArrayBuilder.yml
@@ -1,0 +1,4 @@
+services:
+  neighborhoods.kojo.process.pool.logger.message.serializable_process.from_array_builder:
+    class: Neighborhoods\Kojo\Process\Pool\Logger\Message\SerializableProcess\FromArrayBuilder
+    shared: false

--- a/src/Process/Pool/Logger/Message/SerializableProcess/FromArrayBuilder/AwareTrait.php
+++ b/src/Process/Pool/Logger/Message/SerializableProcess/FromArrayBuilder/AwareTrait.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Kojo\Process\Pool\Logger\Message\SerializableProcess\FromArrayBuilder;
+
+use Neighborhoods\Kojo\Process\Pool\Logger\Message\SerializableProcess\FromArrayBuilderInterface;
+
+/** @codeCoverageIgnore */
+trait AwareTrait
+{
+    protected $NeighborhoodsKojoProcessPoolLoggerMessageSerializableProcessFromArrayBuilder;
+
+    public function setProcessPoolLoggerMessageSerializableProcessFromArrayBuilder(FromArrayBuilderInterface $processPoolLoggerMessageSerializableProcessFromArrayBuilder) : self
+    {
+        if ($this->hasProcessPoolLoggerMessageSerializableProcessFromArrayBuilder()) {
+            throw new \LogicException('NeighborhoodsKojoProcessPoolLoggerMessageSerializableProcessFromArrayBuilder is already set.');
+        }
+        $this->NeighborhoodsKojoProcessPoolLoggerMessageSerializableProcessFromArrayBuilder = $processPoolLoggerMessageSerializableProcessFromArrayBuilder;
+
+        return $this;
+    }
+
+    protected function getProcessPoolLoggerMessageSerializableProcessFromArrayBuilder() : FromArrayBuilderInterface
+    {
+        if (!$this->hasProcessPoolLoggerMessageSerializableProcessFromArrayBuilder()) {
+            throw new \LogicException('NeighborhoodsKojoProcessPoolLoggerMessageSerializableProcessFromArrayBuilder is not set.');
+        }
+
+        return $this->NeighborhoodsKojoProcessPoolLoggerMessageSerializableProcessFromArrayBuilder;
+    }
+
+    protected function hasProcessPoolLoggerMessageSerializableProcessFromArrayBuilder() : bool
+    {
+        return isset($this->NeighborhoodsKojoProcessPoolLoggerMessageSerializableProcessFromArrayBuilder);
+    }
+
+    protected function unsetProcessPoolLoggerMessageSerializableProcessFromArrayBuilder() : self
+    {
+        if (!$this->hasProcessPoolLoggerMessageSerializableProcessFromArrayBuilder()) {
+            throw new \LogicException('NeighborhoodsKojoProcessPoolLoggerMessageSerializableProcessFromArrayBuilder is not set.');
+        }
+        unset($this->NeighborhoodsKojoProcessPoolLoggerMessageSerializableProcessFromArrayBuilder);
+
+        return $this;
+    }
+}

--- a/src/Process/Pool/Logger/Message/SerializableProcess/FromArrayBuilder/Factory.php
+++ b/src/Process/Pool/Logger/Message/SerializableProcess/FromArrayBuilder/Factory.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Kojo\Process\Pool\Logger\Message\SerializableProcess\FromArrayBuilder;
+
+use Neighborhoods\Kojo\Process\Pool\Logger\Message\SerializableProcess\FromArrayBuilderInterface;
+
+/** @codeCoverageIgnore */
+class Factory implements FactoryInterface
+{
+    use AwareTrait;
+
+    public function create() : FromArrayBuilderInterface
+    {
+        return clone $this->getProcessPoolLoggerMessageSerializableProcessFromArrayBuilder();
+    }
+}

--- a/src/Process/Pool/Logger/Message/SerializableProcess/FromArrayBuilder/Factory.yml
+++ b/src/Process/Pool/Logger/Message/SerializableProcess/FromArrayBuilder/Factory.yml
@@ -1,0 +1,5 @@
+services:
+  neighborhoods.kojo.process.pool.logger.message.serializable_process.from_array_builder.factory:
+    class: Neighborhoods\Kojo\Process\Pool\Logger\Message\SerializableProcess\FromArrayBuilder\Factory
+    calls:
+      - [setProcessPoolLoggerMessageSerializableProcessFromArrayBuilder, ['@neighborhoods.kojo.process.pool.logger.message.serializable_process.from_array_builder']]

--- a/src/Process/Pool/Logger/Message/SerializableProcess/FromArrayBuilder/Factory/AwareTrait.php
+++ b/src/Process/Pool/Logger/Message/SerializableProcess/FromArrayBuilder/Factory/AwareTrait.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Kojo\Process\Pool\Logger\Message\SerializableProcess\FromArrayBuilder\Factory;
+
+use Neighborhoods\Kojo\Process\Pool\Logger\Message\SerializableProcess\FromArrayBuilder\FactoryInterface;
+
+/** @codeCoverageIgnore */
+trait AwareTrait
+{
+    protected $NeighborhoodsKojoProcessPoolLoggerMessageSerializableProcessFromArrayBuilderFactory;
+
+    public function setProcessPoolLoggerMessageSerializableProcessFromArrayBuilderFactory(FactoryInterface $processPoolLoggerMessageSerializableProcessFromArrayBuilderFactory) : self
+    {
+        if ($this->hasProcessPoolLoggerMessageSerializableProcessFromArrayBuilderFactory()) {
+            throw new \LogicException('NeighborhoodsKojoProcessPoolLoggerMessageSerializableProcessFromArrayBuilderFactory is already set.');
+        }
+        $this->NeighborhoodsKojoProcessPoolLoggerMessageSerializableProcessFromArrayBuilderFactory = $processPoolLoggerMessageSerializableProcessFromArrayBuilderFactory;
+
+        return $this;
+    }
+
+    protected function getProcessPoolLoggerMessageSerializableProcessFromArrayBuilderFactory() : FactoryInterface
+    {
+        if (!$this->hasProcessPoolLoggerMessageSerializableProcessFromArrayBuilderFactory()) {
+            throw new \LogicException('NeighborhoodsKojoProcessPoolLoggerMessageSerializableProcessFromArrayBuilderFactory is not set.');
+        }
+
+        return $this->NeighborhoodsKojoProcessPoolLoggerMessageSerializableProcessFromArrayBuilderFactory;
+    }
+
+    protected function hasProcessPoolLoggerMessageSerializableProcessFromArrayBuilderFactory() : bool
+    {
+        return isset($this->NeighborhoodsKojoProcessPoolLoggerMessageSerializableProcessFromArrayBuilderFactory);
+    }
+
+    protected function unsetProcessPoolLoggerMessageSerializableProcessFromArrayBuilderFactory() : self
+    {
+        if (!$this->hasProcessPoolLoggerMessageSerializableProcessFromArrayBuilderFactory()) {
+            throw new \LogicException('NeighborhoodsKojoProcessPoolLoggerMessageSerializableProcessFromArrayBuilderFactory is not set.');
+        }
+        unset($this->NeighborhoodsKojoProcessPoolLoggerMessageSerializableProcessFromArrayBuilderFactory);
+
+        return $this;
+    }
+}

--- a/src/Process/Pool/Logger/Message/SerializableProcess/FromArrayBuilder/FactoryInterface.php
+++ b/src/Process/Pool/Logger/Message/SerializableProcess/FromArrayBuilder/FactoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Kojo\Process\Pool\Logger\Message\SerializableProcess\FromArrayBuilder;
+
+use Neighborhoods\Kojo\Process\Pool\Logger\Message\SerializableProcess\FromArrayBuilderInterface;
+
+/** @codeCoverageIgnore */
+interface FactoryInterface
+{
+    public function create() : FromArrayBuilderInterface;
+}

--- a/src/Process/Pool/Logger/Message/SerializableProcess/FromArrayBuilderInterface.php
+++ b/src/Process/Pool/Logger/Message/SerializableProcess/FromArrayBuilderInterface.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Kojo\Process\Pool\Logger\Message\SerializableProcess;
+
+use Neighborhoods\Kojo\Process\Pool\Logger\Message\SerializableProcessInterface;
+
+interface FromArrayBuilderInterface
+{
+    public function setRecord(array $record) : FromArrayBuilderInterface;
+
+    public function build() : SerializableProcessInterface;
+}

--- a/src/Process/Pool/Logger/Message/SerializableProcessInterface.php
+++ b/src/Process/Pool/Logger/Message/SerializableProcessInterface.php
@@ -28,7 +28,13 @@ interface SerializableProcessInterface extends \JsonSerializable
 
     public function getMemoryPeakUsageBytes() : int;
 
+    public function setMemoryUsageBytes(int $memory_usage_bytes) : SerializableProcessInterface;
+
     public function getMemoryUsageBytes() : int;
 
+    public function setMemoryPeakUsageBytes(int $memory_peak_usage_bytes) : SerializableProcessInterface;
+
     public function getMemoryLimitBytes() : int;
+
+    public function setMemoryLimitBytes(int $memory_limit_bytes) : SerializableProcessInterface;
 }


### PR DESCRIPTION
Took a lot more boilerplate than I expected, but now the `Metadata` and all its component parts can be hydrated via `array`s (in this case, from RDBMS JSON)`