### PR TITLE
KOJO-150 | Emit messages for job state changes

### DIFF
--- a/src/Data/Job/FromArrayBuilder.php
+++ b/src/Data/Job/FromArrayBuilder.php
@@ -16,18 +16,18 @@ class FromArrayBuilder implements FromArrayBuilderInterface
         $job = new Data\Job();
         $record = $this->getRecord();
 
-        $job->setId($record['kojo_job_id']);
+        $job->setId((int)$record['kojo_job_id']);
         $job->setAssignedState($record['assigned_state']);
         $job->setNextStateRequest($record['next_state_request']);
         $job->setTypeCode($record['type_code']);
         $job->setName($record['name']);
-        $job->setPriority($record['priority']);
-        $job->setImportance($record['importance']);
+        $job->setPriority((int)$record['priority']);
+        $job->setImportance((int)$record['importance']);
         $job->setWorkAtDateTime(new \DateTime($record['work_at_date_time']));
         $job->setPreviousState($record['previous_state']);
         $job->setWorkerUri($record['worker_uri']);
         $job->setWorkerMethod($record['worker_method']);
-        $job->setCanWorkInParallel($record['can_work_in_parallel']);
+        $job->setCanWorkInParallel((bool)$record['can_work_in_parallel']);
         $job->setLastTransitionInDateTime(new \DateTime($record['last_transition_date_time']));
         $job->setLastTransitionInMicroTime(
             \DateTime::createFromFormat(
@@ -39,11 +39,11 @@ class FromArrayBuilder implements FromArrayBuilderInterface
                 )
             )
         );
-        $job->setTimesWorked($record['times_worked']);
-        $job->setTimesRetried($record['times_retried']);
-        $job->setTimesHeld($record['times_held']);
-        $job->setTimesCrashed($record['times_crashed']);
-        $job->setTimesPanicked($record['times_panicked']);
+        $job->setTimesWorked((int)$record['times_worked']);
+        $job->setTimesRetried((int)$record['times_retried']);
+        $job->setTimesHeld((int)$record['times_held']);
+        $job->setTimesCrashed((int)$record['times_crashed']);
+        $job->setTimesPanicked((int)$record['times_panicked']);
         $job->setCreatedAtDateTime(new \DateTime($record['created_at_date_time']));
 
         if (isset($record['completed_at_date_time'])) {

--- a/src/JobStateChange.php
+++ b/src/JobStateChange.php
@@ -43,4 +43,9 @@ class JobStateChange implements JobStateChangeInterface
         $this->data = $data;
         return $this;
     }
+
+    public function jsonSerialize()
+    {
+        return get_object_vars($this);
+    }
 }

--- a/src/JobStateChangeInterface.php
+++ b/src/JobStateChangeInterface.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Neighborhoods\Kojo;
 
-interface JobStateChangeInterface
+interface JobStateChangeInterface extends \JsonSerializable
 {
     public const PROP_ID = 'id';
     public const PROP_DATA = 'data';

--- a/src/Process/JobStateChangelogProcessor.php
+++ b/src/Process/JobStateChangelogProcessor.php
@@ -56,7 +56,6 @@ class JobStateChangelogProcessor extends Forked implements JobStateChangelogProc
             'event_type' => 'job_state_changelog_processor_bow_out'
         ]);
 
-        // maybe log this to see how often the JSCLP process is replaced?
         return $this;
     }
 

--- a/src/Process/JobStateChangelogProcessor.yml
+++ b/src/Process/JobStateChangelogProcessor.yml
@@ -1,5 +1,6 @@
 parameters:
-  neighborhoods.kojo.process.job_state_changelog_processor.batch_size: 20
+  neighborhoods.kojo.process.job_state_changelog_processor.batch_size: 50
+  neighborhoods.kojo.process.job_state_changelog_processor.num_max_iterations: 100
 services:
   neighborhoods.kojo.process.job_state_changelog_processor:
     class: Neighborhoods\Kojo\Process\JobStateChangelogProcessor
@@ -16,5 +17,6 @@ services:
       - [addSemaphoreResourceFactory, ['@semaphore.resource.factory-job_state_changelog_processor']]
       - [setJobStateChangeRepository, ['@neighborhoods.kojo.job_state_change.repository']]
       - [setBatchSize, ['%neighborhoods.kojo.process.job_state_changelog_processor.batch_size%']]
+      - [setNumMaxIterations, ['%neighborhoods.kojo.process.job_state_changelog_processor.num_max_iterations%']]
   process.job_state_changelog_processor:
     alias: neighborhoods.kojo.process.job_state_changelog_processor

--- a/src/Process/JobStateChangelogProcessor.yml
+++ b/src/Process/JobStateChangelogProcessor.yml
@@ -1,3 +1,5 @@
+parameters:
+  neighborhoods.kojo.process.job_state_changelog_processor.batch_size: 20
 services:
   neighborhoods.kojo.process.job_state_changelog_processor:
     class: Neighborhoods\Kojo\Process\JobStateChangelogProcessor
@@ -12,5 +14,7 @@ services:
       - [setProcessPoolFactory, ['@process.pool.factory-job_state_changelog_processor']]
       - [setTitlePrefix, ['%process.title.prefix%']]
       - [addSemaphoreResourceFactory, ['@semaphore.resource.factory-job_state_changelog_processor']]
+      - [setJobStateChangeRepository, ['@neighborhoods.kojo.job_state_change.repository']]
+      - [setBatchSize, ['%neighborhoods.kojo.process.job_state_changelog_processor.batch_size%']]
   process.job_state_changelog_processor:
     alias: neighborhoods.kojo.process.job_state_changelog_processor

--- a/src/Process/Pool/Strategy.php
+++ b/src/Process/Pool/Strategy.php
@@ -21,7 +21,7 @@ class Strategy extends StrategyAbstract
         } elseif ($process instanceof ListenerInterface) {
             $this->_listenerProcessExited($process);
         } elseif ($process instanceof JobStateChangelogProcessorInterface) {
-            // A new STL process will be created by the Root when appropriate
+            $this->_jobStateChangelogProcessExited($process);
         } else {
             $className = get_class($process);
             throw new \UnexpectedValueException("Unexpected process class[$className].");
@@ -94,6 +94,13 @@ class Strategy extends StrategyAbstract
                 $this->_getProcessPool()->setAlarm($this->getMaxAlarmTime());
             }
         }
+
+        return $this;
+    }
+
+    protected function _jobStateChangelogProcessExited(JobStateChangelogProcessorInterface $jobStateChangelogProcessor) : Strategy
+    {
+        $this->_getProcessPool()->freeChildProcess($jobStateChangelogProcessor->getProcessId());
 
         return $this;
     }

--- a/src/Process/Root.php
+++ b/src/Process/Root.php
@@ -35,6 +35,10 @@ class Root extends Forked
 
     protected function pollSingletonProcesses() : Root
     {
+        if ($this->_getProcessPool()->isFull()) {
+            return $this;
+        }
+
         foreach (self::SINGLETON_PROCESSES as $singletonType) {
             $semaphoreResource = $this->_getSemaphoreResource($singletonType);
 


### PR DESCRIPTION
* Added casts for `Data\Job\FromArrayBuilder` logic because serialization is a mess
* Added logic in JSCLP for reading JSCs from RDBMS, emitting `info` messages, and deleting them. Batch size defaults to 50 but is easily changed from userspace through the parameter YAML file