### PR TITLE
Feature/KOJO-157 | remove deprecated logging structure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ COPY . $PROJECT_DIR
 
 # Copy xdebug configration for remote debugging
 COPY docker/xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini
-COPY docker/bwilson.ini /usr/local/etc/php/conf.d/bwilson.ini
 
 RUN bash docker/build.sh \
     --composer-token ${COMPOSER_TOKEN} \

--- a/src/Process/Pool/Logger/Message.php
+++ b/src/Process/Pool/Logger/Message.php
@@ -23,26 +23,6 @@ class Message implements MessageInterface, \JsonSerializable
     protected $context_json_last_error;
     /** @var MetadataInterface */
     protected $kojo_metadata;
-    /**
-     * @var int
-     * @deprecated
-     */
-    protected $process_id;
-    /**
-     * @var string
-     * @deprecated
-     */
-    protected $process_path;
-    /**
-     * @var JobInterface
-     * @deprecated
-     */
-    protected $kojo_job;
-    /**
-     * @var SerializableProcessInterface
-     * @deprecated
-     */
-    protected $kojo_process;
 
     public function jsonSerialize(): array
     {
@@ -165,70 +145,6 @@ class Message implements MessageInterface, \JsonSerializable
         }
 
         $this->kojo_metadata = $kojo_metadata;
-
-        return $this;
-    }
-
-    /**
-     * @param int $process_id
-     * @return MessageInterface
-     * @deprecated
-     */
-    public function setProcessId(int $process_id) : MessageInterface
-    {
-        if ($this->process_id !== null) {
-            throw new \LogicException('Message process_id is already set.');
-        }
-
-        $this->process_id = $process_id;
-
-        return $this;
-    }
-
-    /**
-     * @param string $process_path
-     * @return MessageInterface
-     * @deprecated
-     */
-    public function setProcessPath(string $process_path) : MessageInterface
-    {
-        if ($this->process_path !== null) {
-            throw new \LogicException('Message process_path is already set.');
-        }
-
-        $this->process_path = $process_path;
-
-        return $this;
-    }
-
-    /**
-     * @param JobInterface $kojo_job
-     * @return MessageInterface
-     * @deprecated
-     */
-    public function setKojoJob(JobInterface $kojo_job) : MessageInterface
-    {
-        if ($this->kojo_job !== null) {
-            throw new \LogicException('Message kojo_job is already set.');
-        }
-
-        $this->kojo_job = $kojo_job;
-
-        return $this;
-    }
-
-    /**
-     * @param SerializableProcessInterface $kojo_process
-     * @return MessageInterface
-     * @deprecated
-     */
-    public function setKojoProcess(SerializableProcessInterface $kojo_process) : MessageInterface
-    {
-        if ($this->kojo_process !== null) {
-            throw new \LogicException('Message kojo_process is already set.');
-        }
-
-        $this->kojo_process = $kojo_process;
 
         return $this;
     }

--- a/src/Process/Pool/Logger/Message/Builder.php
+++ b/src/Process/Pool/Logger/Message/Builder.php
@@ -62,18 +62,8 @@ class Builder implements BuilderInterface
 
         $logMessage->setContextJsonLastError(json_last_error());
 
-        $metadata = $this->getProcessPoolLoggerMessageMetadataBuilder()->build();
-        $logMessage->setMetadata($metadata);
-
-        if ($metadata->hasJob()) {
-            $logMessage->setKojoJob($metadata->getJob());
-        }
-
-        if ($metadata->hasProcess()) {
-            $logMessage->setKojoProcess($metadata->getProcess());
-            $logMessage->setProcessId($metadata->getProcess()->getProcessId());
-            $logMessage->setProcessPath($metadata->getProcess()->getPath());
-        }
+        $kojoMetadata = $this->getProcessPoolLoggerMessageMetadataBuilder()->build();
+        $logMessage->setMetadata($kojoMetadata);
 
         return $logMessage;
     }

--- a/src/Process/Pool/Logger/MessageInterface.php
+++ b/src/Process/Pool/Logger/MessageInterface.php
@@ -33,30 +33,4 @@ interface MessageInterface
     public function setMetadata(MetadataInterface $kojo_metadata) : MessageInterface;
 
     public function getMetadata() : MetadataInterface;
-
-    /** @param int $process_id
-     * @return MessageInterface
-     * @deprecated
-     */
-    public function setProcessId(int $process_id) : MessageInterface;
-
-    /** @param string $process_path
-     * @return MessageInterface
-     * @deprecated
-     */
-    public function setProcessPath(string $process_path) : MessageInterface;
-
-    /**
-     * @param JobInterface $kojo_job
-     * @return MessageInterface
-     * @deprecated
-     */
-    public function setKojoJob(JobInterface $kojo_job) : MessageInterface;
-
-    /**
-     * @param SerializableProcessInterface $kojo_job
-     * @return MessageInterface
-     * @deprecated
-     */
-    public function setKojoProcess(SerializableProcessInterface $kojo_job) : MessageInterface;
 }


### PR DESCRIPTION
## Target Release
- This will be the first release targeted to the 5.x release of Kōjō. 

## Changes
- Remove the following top level logging keys in favor the of the `kojo_metadata` structure as documented in the [4.15.0 release notes](https://github.com/neighborhoods/kojo/releases/tag/4.15.0):
  - kojo_process
  - kojo_job
  - process_id
  - process_path