### PR TITLE
KOJO-96 | Panic job instead of crashing on userspace exceptions

### DIFF
--- a/src/Foreman.yml
+++ b/src/Foreman.yml
@@ -11,7 +11,6 @@ services:
     - [addSemaphoreResourceFactory, ['@semaphore.resource.factory-job']]
     - [setServiceUpdateWorkFactory, ['@service.update.work.factory']]
     - [setServiceUpdatePanicFactory, ['@service.update.panic.factory']]
-    - [setServiceUpdateCrashFactory, ['@service.update.crash.factory']]
     - [setServiceUpdateCompleteSuccessFactory, ['@service.update.complete.success.factory']]
     - [setLogger, ['@process.pool.logger']]
     - [setProcessPoolLoggerMessageMetadataBuilder, ['@neighborhoods.kojo.process.pool.logger.message.metadata.builder']]


### PR DESCRIPTION
The error handler is really just a safety net, as a general rule we should be `catch`ing `Error`s

Because the crash vs panic behavior affects userspace (and "times crashed" is exposed through the Worker Service API), this is going into 5.x

Any users upgrading to the version this PR goes into will have to make sure they're not relying on "crash-loop" behavior. If retrying a job when an exception is thrown is desirable behavior, the exception must be caught in userspace, and the Worker Service API must be used to request a retry