### PR TITLE
KOJO-96 | Removing unnecessary interface method

### DIFF
--- a/src/ForemanInterface.php
+++ b/src/ForemanInterface.php
@@ -12,7 +12,5 @@ interface ForemanInterface
 
     public function setServiceUpdateWorkFactory(Update\Work\FactoryInterface $updateWorkFactory);
 
-    public function setServiceUpdateCrashFactory(Update\Crash\FactoryInterface $updateCrashFactory);
-
     public function setApiV1WorkerService(ServiceInterface $workerService);
 }


### PR DESCRIPTION
One minor addition to https://github.com/neighborhoods/kojo/pull/91/files

I dunno why my earlier testing didn't hit this problem, probably some autoloader or DI caching