### PR TITLE
KOJO-180 | Clean up Root's Process Pool after JSCLP exit

### DIFF
--- a/src/Process/Pool/Strategy.php
+++ b/src/Process/Pool/Strategy.php
@@ -21,7 +21,7 @@ class Strategy extends StrategyAbstract
         } elseif ($process instanceof ListenerInterface) {
             $this->_listenerProcessExited($process);
         } elseif ($process instanceof JobStateChangelogProcessorInterface) {
-            // A new STL process will be created by the Root when appropriate
+            $this->_jobStateChangelogProcessorProcessExited($process);
         } else {
             $className = get_class($process);
             throw new \UnexpectedValueException("Unexpected process class[$className].");
@@ -93,6 +93,20 @@ class Strategy extends StrategyAbstract
             if (!$this->_getProcessPool()->hasAlarm()) {
                 $this->_getProcessPool()->setAlarm($this->getMaxAlarmTime());
             }
+        }
+
+        return $this;
+    }
+
+    protected function _jobStateChangelogProcessorProcessExited(JobStateChangelogProcessorInterface $jsclpProcess) : Strategy
+    {
+        $this->_getProcessPool()->freeChildProcess($jsclpProcess->getProcessId());
+
+        // usually this is where we'd spawn a new JSCLP to take the place of the one that exited, but
+        // that is handled by \Neighborhoods\Kojo\Process\Root::pollSingletonProcesses()
+
+        if (!$this->_getProcessPool()->hasAlarm()) {
+            $this->_getProcessPool()->setAlarm($this->getMaxAlarmTime());
         }
 
         return $this;


### PR DESCRIPTION
When I added this stuff, I treated this `SIGCHLD`-handler-triggered method as if it was only responsible to replacing the exited process (which the JSCLP doesn't need), but it's also where the Root's process pool model gets cleaned up and re-synchronized with reality