### PR TITLE
KOJO-178 | Guard against full process pool when Root is polling singletons

### DIFF
--- a/src/Process/Root.php
+++ b/src/Process/Root.php
@@ -43,7 +43,9 @@ class Root extends Forked
             if ($semaphoreResource->testLock()) {
                 try {
                     $process = $this->_getProcessCollection()->getProcessPrototypeClone($singletonType);
-                    $this->_getProcessPool()->addChildProcess($process);
+                    if (!$this->_getProcessPool()->isFull()) {
+                        $this->_getProcessPool()->addChildProcess($process);
+                    }
                 } catch (Forked\Exception $forkedException) {
                     // this is fine, another execution environment will spawn this process
                     // TODO: consider breaking here to stop attempting to spawn other singletons


### PR DESCRIPTION
In situations where an execution environment starts up and there are many "pending job" messages in redis, the previous version of the code would attempt to add singletons to an already-full process pool