### PR TITLE
KOJO-173 | Auto-migration logic

### DIFF
--- a/src/Process/Pool/Server.php
+++ b/src/Process/Pool/Server.php
@@ -25,10 +25,10 @@ class Server extends ProcessAbstract implements ServerInterface
         $this->_initialize();
         $this->_getLogger()->debug('Starting process pool server...');
         if ($this->_getSemaphore()->testAndSetLock($this->_getServerSemaphoreResource())) {
+            $this->_getLogger()->debug('Process pool server started.');
             $this->_getDbSetup()->install();
             $this->_getLogger()->debug('Migrations run.');
             $this->_getProcessPool()->start();
-            $this->_getLogger()->debug('Process pool server started.');
             while (true) {
                 $this->getProcessSignalDispatcher()->processBufferedSignals();
                 sleep(1);

--- a/src/Process/Pool/Server.php
+++ b/src/Process/Pool/Server.php
@@ -8,6 +8,7 @@ use Neighborhoods\Kojo\ProcessAbstract;
 use Neighborhoods\Kojo\ProcessInterface;
 use Neighborhoods\Kojo\Semaphore;
 use Neighborhoods\Pylon\Data\Property;
+use Neighborhoods\Kojo\Db;
 
 class Server extends ProcessAbstract implements ServerInterface
 {
@@ -15,6 +16,7 @@ class Server extends ProcessAbstract implements ServerInterface
     use Logger\AwareTrait;
     use Semaphore\AwareTrait;
     use Semaphore\Resource\Factory\AwareTrait;
+    use Db\Setup\AwareTrait;
 
     public const SERVER_SEMAPHORE_RESOURCE_NAME = 'server';
 
@@ -23,8 +25,10 @@ class Server extends ProcessAbstract implements ServerInterface
         $this->_initialize();
         $this->_getLogger()->debug('Starting process pool server...');
         if ($this->_getSemaphore()->testAndSetLock($this->_getServerSemaphoreResource())) {
-            $this->_getLogger()->debug('Process pool server started.');
+            $this->_getDbSetup()->install();
+            $this->_getLogger()->debug('Migrations run.');
             $this->_getProcessPool()->start();
+            $this->_getLogger()->debug('Process pool server started.');
             while (true) {
                 $this->getProcessSignalDispatcher()->processBufferedSignals();
                 sleep(1);

--- a/src/Process/Pool/Server.yml
+++ b/src/Process/Pool/Server.yml
@@ -8,6 +8,7 @@ services:
       - [setSemaphore, ['@semaphore']]
       - [addSemaphoreResourceFactory, ['@semaphore.resource.factory-server']]
       - [setProcessPoolFactory, ['@process.pool.factory-server']]
+      - [setDbSetup, ['@db.setup']]
       - [setTypeCode, ['server']]
       - [setTerminationSignalNumber, ['@=constant("SIGTERM")']]
       - [setUuidMaximumInteger, [9999999999]]


### PR DESCRIPTION
Exactly what it says on the tin

There has always existed a [critical region](https://github.com/neighborhoods/kojo/blob/5.x/src/Db/Schema/VersionAbstract.php#L23-L37) for migrations, since it's possible to run multiple instances of `kojo db:setup:install` concurrently, but it was very unlikely until we decided that we want the server process to automatically run any available migrations on startup. Considering that schema exceptions bubbling up from the critical region into the server process would cause the kojo runtime to crash, I added some guards so migrations run from either entrypoint would handle them gracefully

[Related KojoFitness UseCase](https://github.com/neighborhoods/KojoFitness/pull/26)