### PR TITLE
KOJO-191 | implement reload() method and mark it as deprecated

### DIFF
--- a/src/Api/V1/Worker/ServiceInterface.php
+++ b/src/Api/V1/Worker/ServiceInterface.php
@@ -30,6 +30,7 @@ interface ServiceInterface
 
     public function getNewJobScheduler(): SchedulerInterface;
 
+    /** @deprecated  */
     public function reload(): ServiceInterface;
 
     public function getTimesCrashed(): int;


### PR DESCRIPTION
- implement `reload()` method and mark it as deprecated since removing it is a breaking change
- If `applyRequest()` is double called, internally call `reload()` and then recursively call `applyRequest()` again. 