### PR TITLE
HOTFIX | Stop spawning JSCLP process

### DIFF
--- a/src/Process/Root.php
+++ b/src/Process/Root.php
@@ -26,7 +26,7 @@ class Root extends Forked
 
         while (true) {
             $this->getProcessSignalDispatcher()->processBufferedSignals();
-            $this->pollSingletonProcesses();
+            // $this->pollSingletonProcesses();
             sleep(1);
         }
 


### PR DESCRIPTION
It's not doing anything currently and the process is being weird in some edge cases for agent service