### PR TITLE
KOJO-201 | add API\V1 AwareInterfaces

### DIFF
--- a/src/Api/V1/Job/Scheduler/AwareInterface.php
+++ b/src/Api/V1/Job/Scheduler/AwareInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neighborhoods\Kojo\Api\V1\Job\Scheduler;
+
+use Neighborhoods\Kojo\Api\V1\Job\SchedulerInterface;
+
+interface AwareInterface
+{
+    public function setApiV1JobScheduler(SchedulerInterface $apiV1JobScheduler): self;
+}

--- a/src/Api/V1/Job/Scheduler/AwareInterface.php
+++ b/src/Api/V1/Job/Scheduler/AwareInterface.php
@@ -8,5 +8,5 @@ use Neighborhoods\Kojo\Api\V1\Job\SchedulerInterface;
 
 interface AwareInterface
 {
-    public function setApiV1JobScheduler(SchedulerInterface $apiV1JobScheduler): self;
+    public function setApiV1JobScheduler(SchedulerInterface $apiV1JobScheduler);
 }

--- a/src/Api/V1/Job/Scheduler/Factory/AwareInterface.php
+++ b/src/Api/V1/Job/Scheduler/Factory/AwareInterface.php
@@ -8,5 +8,5 @@ use Neighborhoods\Kojo\Api\V1\Job\Scheduler\FactoryInterface;
 
 interface AwareInterface
 {
-    public function setApiV1JobSchedulerFactory(FactoryInterface $apiV1JobSchedulerFactory): self;
+    public function setApiV1JobSchedulerFactory(FactoryInterface $apiV1JobSchedulerFactory);
 }

--- a/src/Api/V1/Job/Scheduler/Factory/AwareInterface.php
+++ b/src/Api/V1/Job/Scheduler/Factory/AwareInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neighborhoods\Kojo\Api\V1\Job\Scheduler\Factory;
+
+use Neighborhoods\Kojo\Api\V1\Job\Scheduler\FactoryInterface;
+
+interface AwareInterface
+{
+    public function setApiV1JobSchedulerFactory(FactoryInterface $apiV1JobSchedulerFactory): self;
+}

--- a/src/Api/V1/Job/Scheduler/FactoryInterface.php
+++ b/src/Api/V1/Job/Scheduler/FactoryInterface.php
@@ -6,12 +6,9 @@ namespace Neighborhoods\Kojo\Api\V1\Job\Scheduler;
 use Neighborhoods\Kojo\Api\V1\Job\SchedulerInterface;
 use Neighborhoods\Kojo\Service;
 
-interface FactoryInterface
+interface FactoryInterface extends AwareInterface
 {
     public function create(): SchedulerInterface;
-
-    /** @injected:configuration */
-    public function setApiV1JobScheduler(SchedulerInterface $apiV1JobScheduler);
 
     /** @injected:configuration */
     public function setServiceCreateFactory(Service\Create\FactoryInterface $serviceCreateFactory);

--- a/src/Api/V1/Job/Type/Registrar/AwareInterface.php
+++ b/src/Api/V1/Job/Type/Registrar/AwareInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neighborhoods\Kojo\Api\V1\Job\Type\Registrar;
+
+use Neighborhoods\Kojo\Api\V1\Job\Type\RegistrarInterface;
+
+interface AwareInterface
+{
+    public function setApiV1JobTypeRegistrar(RegistrarInterface $apiV1JobTypeRegistrar): self;
+}

--- a/src/Api/V1/Job/Type/Registrar/AwareInterface.php
+++ b/src/Api/V1/Job/Type/Registrar/AwareInterface.php
@@ -8,5 +8,5 @@ use Neighborhoods\Kojo\Api\V1\Job\Type\RegistrarInterface;
 
 interface AwareInterface
 {
-    public function setApiV1JobTypeRegistrar(RegistrarInterface $apiV1JobTypeRegistrar): self;
+    public function setApiV1JobTypeRegistrar(RegistrarInterface $apiV1JobTypeRegistrar);
 }

--- a/src/Api/V1/Job/Type/Registrar/Factory/AwareInterface.php
+++ b/src/Api/V1/Job/Type/Registrar/Factory/AwareInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neighborhoods\Kojo\Api\V1\Job\Type\Registrar\Factory;
+
+use Neighborhoods\Kojo\Api\V1\Job\Type\Registrar\FactoryInterface;
+
+interface AwareInterface
+{
+    public function setApiV1JobTypeRegistrarFactory(FactoryInterface $apiV1JobTypeRegistrarFactory): self;
+}

--- a/src/Api/V1/Job/Type/Registrar/Factory/AwareInterface.php
+++ b/src/Api/V1/Job/Type/Registrar/Factory/AwareInterface.php
@@ -8,5 +8,5 @@ use Neighborhoods\Kojo\Api\V1\Job\Type\Registrar\FactoryInterface;
 
 interface AwareInterface
 {
-    public function setApiV1JobTypeRegistrarFactory(FactoryInterface $apiV1JobTypeRegistrarFactory): self;
+    public function setApiV1JobTypeRegistrarFactory(FactoryInterface $apiV1JobTypeRegistrarFactory);
 }

--- a/src/Api/V1/Job/Type/Registrar/FactoryInterface.php
+++ b/src/Api/V1/Job/Type/Registrar/FactoryInterface.php
@@ -5,7 +5,7 @@ namespace Neighborhoods\Kojo\Api\V1\Job\Type\Registrar;
 
 use Neighborhoods\Kojo\Api\V1\Job\Type\RegistrarInterface;
 
-interface FactoryInterface
+interface FactoryInterface extends AwareInterface
 {
     public function create(): RegistrarInterface;
 }

--- a/src/Api/V1/Logger/AwareInterface.php
+++ b/src/Api/V1/Logger/AwareInterface.php
@@ -8,5 +8,5 @@ use Neighborhoods\Kojo\Api\V1\LoggerInterface;
 
 interface AwareInterface
 {
-    public function setApiV1Logger(LoggerInterface $apiV1Logger): self;
+    public function setApiV1Logger(LoggerInterface $apiV1Logger);
 }

--- a/src/Api/V1/Logger/AwareInterface.php
+++ b/src/Api/V1/Logger/AwareInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neighborhoods\Kojo\Api\V1\Logger;
+
+use Neighborhoods\Kojo\Api\V1\LoggerInterface;
+
+interface AwareInterface
+{
+    public function setApiV1Logger(LoggerInterface $apiV1Logger): self;
+}

--- a/src/Api/V1/RDBMS/Connection/Service/AwareInterface.php
+++ b/src/Api/V1/RDBMS/Connection/Service/AwareInterface.php
@@ -8,5 +8,5 @@ use Neighborhoods\Kojo\Api\V1\RDBMS\Connection\ServiceInterface;
 
 interface AwareInterface
 {
-    public function setApiV1RDBMSConnectionService(ServiceInterface $ApiV1RDBMSConnectionService): self;
+    public function setApiV1RDBMSConnectionService(ServiceInterface $ApiV1RDBMSConnectionService);
 }

--- a/src/Api/V1/RDBMS/Connection/Service/AwareInterface.php
+++ b/src/Api/V1/RDBMS/Connection/Service/AwareInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neighborhoods\Kojo\Api\V1\RDBMS\Connection\Service;
+
+use Neighborhoods\Kojo\Api\V1\RDBMS\Connection\ServiceInterface;
+
+interface AwareInterface
+{
+    public function setApiV1RDBMSConnectionService(ServiceInterface $ApiV1RDBMSConnectionService): self;
+}

--- a/src/Api/V1/Worker/Service/AwareInterface.php
+++ b/src/Api/V1/Worker/Service/AwareInterface.php
@@ -8,5 +8,5 @@ use Neighborhoods\Kojo\Api\V1\Worker\ServiceInterface;
 
 interface AwareInterface
 {
-    public function setApiV1WorkerService(ServiceInterface $apiV1WorkerService): self;
+    public function setApiV1WorkerService(ServiceInterface $apiV1WorkerService);
 }

--- a/src/Api/V1/Worker/Service/AwareInterface.php
+++ b/src/Api/V1/Worker/Service/AwareInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neighborhoods\Kojo\Api\V1\Worker\Service;
+
+use Neighborhoods\Kojo\Api\V1\Worker\ServiceInterface;
+
+interface AwareInterface
+{
+    public function setApiV1WorkerService(ServiceInterface $apiV1WorkerService): self;
+}

--- a/src/Api/V1/Worker/ServiceInterface.php
+++ b/src/Api/V1/Worker/ServiceInterface.php
@@ -3,7 +3,9 @@ declare(strict_types=1);
 
 namespace Neighborhoods\Kojo\Api\V1\Worker;
 
+use Neighborhoods\Kojo\Api\V1\Job\Scheduler;
 use Neighborhoods\Kojo\Api\V1\Job\SchedulerInterface;
+use Neighborhoods\Kojo\Api\V1\Logger;
 use Neighborhoods\Kojo\Api\V1\LoggerInterface;
 use Neighborhoods\Kojo\Data\JobInterface;
 use Neighborhoods\Kojo\Service\Update\Hold;
@@ -12,7 +14,7 @@ use Neighborhoods\Kojo\Service\Update\Complete\Success;
 use Neighborhoods\Kojo\Service\Update\Complete\Failed;
 use Neighborhoods\Kojo\Apm;
 
-interface ServiceInterface
+interface ServiceInterface extends Scheduler\Factory\AwareInterface, Logger\AwareInterface
 {
     public function requestRetry(\DateTime $retryDateTime): ServiceInterface;
 

--- a/src/ForemanInterface.php
+++ b/src/ForemanInterface.php
@@ -3,14 +3,13 @@ declare(strict_types=1);
 
 namespace Neighborhoods\Kojo;
 
+use Neighborhoods\Kojo\Api\V1\RDBMS\Connection;
+use Neighborhoods\Kojo\Api\V1\Worker;
 use Neighborhoods\Kojo\Service\Update;
-use Neighborhoods\Kojo\Api\V1\Worker\ServiceInterface;
 
-interface ForemanInterface
+interface ForemanInterface extends Connection\Service\AwareInterface, Worker\Service\AwareInterface
 {
     public function workWorker(): ForemanInterface;
 
     public function setServiceUpdateWorkFactory(Update\Work\FactoryInterface $updateWorkFactory);
-
-    public function setApiV1WorkerService(ServiceInterface $workerService);
 }

--- a/src/ForemanInterface.php
+++ b/src/ForemanInterface.php
@@ -7,7 +7,7 @@ use Neighborhoods\Kojo\Api\V1\RDBMS\Connection;
 use Neighborhoods\Kojo\Api\V1\Worker;
 use Neighborhoods\Kojo\Service\Update;
 
-interface ForemanInterface extends Connection\Service\AwareInterface, Worker\Service\AwareInterface
+interface ForemanInterface
 {
     public function workWorker(): ForemanInterface;
 


### PR DESCRIPTION
I had to drop the `: self` from the return signatures because those are only allowed in PHP 7.4 which supports covariant return types. PHP 7.2 only has limited covariance in that you can go from nothing on the interface to something on the actual class.

The two big ones that are really useful are the `Worker\Service\AwareInterface` and the `Connection\Service\AwareInterface`, but I figured that putting them into everything in the `Api\V1` directory can't hurt and that it's easier to remove things than to add them.

If you don't like the AwareInterfaces on the interfaces that actually use them, I can re-open the PR from one-commit higher up the chain (cleaner than including a revert commit, IMO)