### PR TITLE
KOJO-224 | Configurable disabled job type log level

### DIFF
--- a/src/Environment/Parameters.yml
+++ b/src/Environment/Parameters.yml
@@ -8,3 +8,5 @@ parameters:
   neighborhoods.kojo.environment.parameters.database_port: 0
   neighborhoods.kojo.environment.parameters.database_name: ''
   neighborhoods.kojo.environment.parameters.lock_prefix: ''
+  neighborhoods.kojo.environment.parameters.kojospace_logging_levels:
+    disabled_job_type: !php/const \Psr\Log\LogLevel::WARNING

--- a/src/Environment/Parameters.yml
+++ b/src/Environment/Parameters.yml
@@ -8,5 +8,4 @@ parameters:
   neighborhoods.kojo.environment.parameters.database_port: 0
   neighborhoods.kojo.environment.parameters.database_name: ''
   neighborhoods.kojo.environment.parameters.lock_prefix: ''
-  neighborhoods.kojo.environment.parameters.kojospace_logging_levels:
-    disabled_job_type: !php/const \Psr\Log\LogLevel::WARNING
+  neighborhoods.kojo.environment.parameters.kojospace_logging_levels.disabled_job_type: !php/const \Psr\Log\LogLevel::WARNING

--- a/src/Scheduler.yml
+++ b/src/Scheduler.yml
@@ -1,3 +1,5 @@
+parameters:
+  neighborhoods.kojo.scheduler.disabled_job_type_log_level: '%neighborhoods.kojo.environment.parameters.kojospace_logging_levels.disabled_job_type%'
 services:
   neighborhoods.kojo.scheduler:
     class: Neighborhoods\Kojo\Scheduler
@@ -11,6 +13,7 @@ services:
       - [addSemaphoreResourceFactory, ['@semaphore.resource.factory-schedule']]
       - [setSchedulerCache, ['@scheduler.cache']]
       - [setLogger, ['@process.pool.logger']]
+      - [setDisabledJobTypeLogLevel, ['%neighborhoods.kojo.scheduler.disabled_job_type_log_level%']]
   scheduler:
     alias: neighborhoods.kojo.scheduler
     public: false

--- a/src/SchedulerInterface.php
+++ b/src/SchedulerInterface.php
@@ -11,5 +11,7 @@ interface SchedulerInterface
 
     public function setSchedulerCache(CacheInterface $schedulerCache);
 
+    public function setDisabledJobTypeLogLevel(string $disabledJobTypeLogLevel) : SchedulerInterface;
+
     public function scheduleStaticJobs(): SchedulerInterface;
 }


### PR DESCRIPTION
1. Exposes a DI YML parameter called `neighborhoods.kojo.environment.parameters.kojospace_logging_levels.disabled_job_type` that userspace can override (see https://github.com/neighborhoods/KojoFitness/pull/33 for examples)

2. Verifies valid values for the log level in that parameter

3. Logs using that log level

I'm not attached to any of the names or locations, let me know if you have anything better